### PR TITLE
Don't enable the hyper http1 feature now that hyper 0.14.2 is out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/ctz/hyper-rustls"
 log = "0.4.4"
 ct-logs = { version = "^0.8", optional = true }
 futures-util = "0.3.1"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1"] }
+hyper = { version = "0.14.2", default-features = false, features = ["client"] }
 rustls = "0.19"
 rustls-native-certs = { version = "0.5.0", optional = true }
 tokio = "1.0"


### PR DESCRIPTION
Starting from hyper 0.14.2 http connection types don't require a specific proto feature to be enabled in order to be accessed.

See https://github.com/hyperium/hyper/pull/2377