### PR TITLE
Add HttpsConnectorBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,10 @@ futures-util = { version = "0.3.1", default-features = false }
 
 [features]
 default = ["native-tokio"]
+http2 = ["hyper/http2"]
 webpki-tokio = ["tokio-runtime", "webpki-roots"]
 native-tokio = ["tokio-runtime", "rustls-native-certs"]
-tokio-runtime =  ["hyper/runtime", "ct-logs"]
+tokio-runtime =  ["hyper/tcp", "ct-logs"]
 
 [[example]]
 name = "client"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -55,7 +55,7 @@ async fn run_client() -> io::Result<()> {
             hyper_rustls::HttpsConnector::from((http, tls))
         }
         // Default HTTPS connector.
-        None => hyper_rustls::HttpsConnector::with_native_roots(),
+        None => hyper_rustls::HttpsConnectorBuilder::with_native_roots().build(),
     };
 
     // Build the hyper client from the HTTPS connector.

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -22,6 +22,30 @@ pub struct HttpsConnector<T> {
     tls_config: Arc<ClientConfig>,
 }
 
+#[cfg(all(
+    any(feature = "rustls-native-certs", feature = "webpki-roots"),
+    feature = "tokio-runtime"
+))]
+impl HttpsConnector<HttpConnector> {
+    /// Construct a new `HttpsConnector` using the OS root store
+    #[cfg(feature = "rustls-native-certs")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
+    pub fn with_native_roots() -> Self {
+        HttpsConnectorBuilder::with_native_roots()
+            .enable_cert_transparency()
+            .build()
+    }
+
+    /// Construct a new `HttpsConnector` using the `webpki_roots`
+    #[cfg(feature = "webpki-roots")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
+    pub fn with_webpki_roots() -> Self {
+        HttpsConnectorBuilder::with_webpki_roots()
+            .enable_cert_transparency()
+            .build()
+    }
+}
+
 /// A builder that will configure an `HttpsConnector`
 ///
 /// This builder ensures configuration is consistent.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! let mut rt = tokio::runtime::Runtime::new().unwrap();
 //! let url = ("https://hyper.rs").parse().unwrap();
-//! let https = hyper_rustls::HttpsConnector::with_native_roots();
+//! let https = hyper_rustls::HttpsConnectorBuilder::with_native_roots().build();
 //!
 //! let client: Client<_, hyper::Body> = Client::builder().build(https);
 //!
@@ -27,5 +27,5 @@
 mod connector;
 mod stream;
 
-pub use crate::connector::HttpsConnector;
+pub use crate::connector::{HttpsConnector, HttpsConnectorBuilder};
 pub use crate::stream::MaybeHttpsStream;


### PR DESCRIPTION
This gives more control over various rustls features,
as well as ensures that enabling connector features
like http2 can only be done when the appropriate crate
features are enabled.

Adds an hyper-rustls/http2 feature, fixing #143.

This is an alternative to the fix in #144, my motivation is that crate features can be activated at a remote whereas an explicit method call removes ambiguity.