### PR TITLE
Upgrade to rustls 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ repository = "https://github.com/ctz/hyper-rustls"
 
 [dependencies]
 log = "0.4.4"
-ct-logs = { version = "^0.8", optional = true }
+ct-logs = { version = "^0.9", optional = true }
 hyper = { version = "0.14", default-features = false, features = ["client", "http1"] }
-rustls = "0.19"
-rustls-native-certs = { version = "0.5.0", optional = true }
+rustls = { git = "https://github.com/ctz/rustls" }
+rustls-native-certs = { git = "https://github.com/djc/rustls-native-certs", rev = "6116ef59f5825b0ec74a38807635a70433d68c27", optional = true }
+rustls-pemfile = { version = "0.2.1" }
 tokio = "1.0"
-tokio-rustls = "0.22"
-webpki = "0.21.0"
-webpki-roots = { version = "0.21", optional = true }
+tokio-rustls = { version = "0.23", git = "https://github.com/tokio-rs/tls", rev = "b433932bf1025960e5b99f353cf8eee4ce2f08f3" }
+webpki = "0.22.0"
+webpki-roots = { version = "0.22", optional = true }
 
 [dev-dependencies]
 async-stream = "0.3.0"
@@ -45,3 +46,6 @@ required-features = ["tokio-runtime"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch."crates-io"]
+rustls = { git = "https://github.com/ctz/rustls" }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,15 +4,15 @@
 //! Certificate and private key are hardcoded to sample files.
 //! hyper will automatically use HTTP/2 if a client starts talking HTTP/2,
 //! otherwise HTTP/1.1 will be used.
+use std::pin::Pin;
+use std::vec::Vec;
+use std::{env, fs, io, sync};
+
 use async_stream::stream;
 use core::task::{Context, Poll};
 use futures_util::{future::TryFutureExt, stream::Stream};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
-use rustls::internal::pemfile;
-use std::pin::Pin;
-use std::vec::Vec;
-use std::{env, fs, io, sync};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::server::TlsStream;
 use tokio_rustls::TlsAcceptor;
@@ -45,12 +45,13 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Load private key.
         let key = load_private_key("examples/sample.rsa")?;
         // Do not use client certificate authentication.
-        let mut cfg = rustls::ServerConfig::new(rustls::NoClientAuth::new());
-        // Select a certificate to use.
-        cfg.set_single_cert(certs, key)
+        let mut cfg = rustls::ServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
             .map_err(|e| error(format!("{}", e)))?;
         // Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
-        cfg.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec()]);
+        cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         sync::Arc::new(cfg)
     };
 
@@ -127,7 +128,9 @@ fn load_certs(filename: &str) -> io::Result<Vec<rustls::Certificate>> {
     let mut reader = io::BufReader::new(certfile);
 
     // Load and return certificate.
-    pemfile::certs(&mut reader).map_err(|_| error("failed to load certificate".into()))
+    let certs = rustls_pemfile::certs(&mut reader)
+        .map_err(|_| error("failed to load certificate".into()))?;
+    Ok(certs.into_iter().map(rustls::Certificate).collect())
 }
 
 // Load private key from file.
@@ -138,10 +141,11 @@ fn load_private_key(filename: &str) -> io::Result<rustls::PrivateKey> {
     let mut reader = io::BufReader::new(keyfile);
 
     // Load and return a single private key.
-    let keys = pemfile::rsa_private_keys(&mut reader)
+    let keys = rustls_pemfile::rsa_private_keys(&mut reader)
         .map_err(|_| error("failed to load private key".into()))?;
     if keys.len() != 1 {
         return Err(error("expected a single private key".into()));
     }
-    Ok(keys[0].clone())
+
+    Ok(rustls::PrivateKey(keys[0].clone()))
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,9 +6,9 @@ use std::task::{Context, Poll};
 
 use hyper::client::connect::{Connected, Connection};
 
-use rustls::Session;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::{Connection as _};
 
 /// A stream that might be protected with TLS.
 pub enum MaybeHttpsStream<T> {
@@ -24,7 +24,7 @@ impl<T: AsyncRead + AsyncWrite + Connection + Unpin> Connection for MaybeHttpsSt
             MaybeHttpsStream::Http(s) => s.connected(),
             MaybeHttpsStream::Https(s) => {
                 let (tcp, tls) = s.get_ref();
-                if tls.get_alpn_protocol() == Some(b"h2") {
+                if tls.alpn_protocol() == Some(b"h2") {
                     tcp.connected().negotiated_h2()
                 } else {
                     tcp.connected()


### PR DESCRIPTION
This is blocked on tokio-rustls and rustls-native certs releasing updates, first.