### PR TITLE
Document dependency on `http2` feature

### DIFF
--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -161,6 +161,7 @@ impl ConnectorBuilder<WantsProtocols1> {
     ///
     /// This needs to be called explicitly, no protocol is enabled by default
     #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn enable_http2(mut self) -> ConnectorBuilder<WantsProtocols3> {
         self.0.tls_config.alpn_protocols = vec![b"h2".to_vec()];
         ConnectorBuilder(WantsProtocols3 {
@@ -185,6 +186,7 @@ impl ConnectorBuilder<WantsProtocols2> {
     ///
     /// This needs to be called explicitly, no protocol is enabled by default
     #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn enable_http2(mut self) -> ConnectorBuilder<WantsProtocols3> {
         self.0.inner.tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         ConnectorBuilder(WantsProtocols3 {


### PR DESCRIPTION
Annotates the rustdoc on `ConnectorBuilder<WantsProtocols{1,2}>::enable_http2`
so that docs.rs will plainly tell users that crate feature `http2` must
be enabled.