### PR TITLE
Prepare 0.23.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ and the [hyper HTTP library](https://github.com/hyperium/hyper).
 [![Documentation](https://docs.rs/hyper-rustls/badge.svg)](https://docs.rs/hyper-rustls/)
 
 # Release history
+- 0.23.1 (2022-10-26):
+  * Allow overriding the servername. Thanks to @MikailBag.
 - 0.23.0 (2021-11-21):
   * Upgrade to rustls 0.20. Thanks to @g2p.
   * Add new HttpsConnectorBuilder API. Thanks to @g2p.


### PR DESCRIPTION
As requested in #177.

- [x] Updated changelog
- [x] Checked for outdated dependencies
- [x] Ran the tests locally (with `--all-features`)
- [x] Bumped the version number
- [x] `cargo publish --dry-run`