### PR TITLE
Prepare 0.23.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "hyper-rustls"
 version = "0.23.2"
 edition = "2018"
-authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"
 description = "Rustls+hyper integration for pure rust HTTPS"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ and the [hyper HTTP library](https://github.com/hyperium/hyper).
 [![Documentation](https://docs.rs/hyper-rustls/badge.svg)](https://docs.rs/hyper-rustls/)
 
 # Release history
+- 0.23.2 (2022-12-08):
+  * Strip brackets from IPv6 addresses in the servername. Thanks to @digitwolf.
 - 0.23.1 (2022-10-26):
   * Allow overriding the servername. Thanks to @MikailBag.
 - 0.23.0 (2021-11-21):


### PR DESCRIPTION
As requested in #182.

- [x] Updated changelog
- [x] Checked for up-to-date dependencies
- [x] Ran `cargo test --all-features`
- [x] Updated `Cargo.toml` with the new version
- [x] Ran `cargo publish --dry-run`