### PR TITLE
tests: support CARGO_TARGET_DIR env variable

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,35 @@
+use std::env;
+use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
 use std::time;
 
+fn target_dir() -> PathBuf {
+    env::var("CARGO_TARGET_DIR")
+        .unwrap_or_else(|_| "target".to_string())
+        .into()
+}
+
+fn examples_dir() -> PathBuf {
+    target_dir()
+        .join("debug")
+        .join("examples")
+}
+
+fn server_command() -> Command {
+    let server_bin_path = examples_dir().join("server");
+    Command::new(server_bin_path)
+}
+
+fn client_command() -> Command {
+    let client_bin_path = examples_dir().join("client");
+    println!("client_bin_path: {:?}", client_bin_path);
+    Command::new(client_bin_path)
+}
+
 #[test]
 fn client() {
-    let rc = Command::new("target/debug/examples/client")
+    let rc = client_command()
         .arg("https://google.com")
         .output()
         .expect("cannot run client example");
@@ -14,7 +39,7 @@ fn client() {
 
 #[test]
 fn server() {
-    let mut srv = Command::new("target/debug/examples/server")
+    let mut srv = server_command()
         .arg("1337")
         .spawn()
         .expect("cannot run server example");
@@ -37,14 +62,14 @@ fn server() {
 
 #[test]
 fn custom_ca_store() {
-    let mut srv = Command::new("target/debug/examples/server")
+    let mut srv = server_command()
         .arg("1338")
         .spawn()
         .expect("cannot run server example");
 
     thread::sleep(time::Duration::from_secs(1));
 
-    let rc = Command::new("target/debug/examples/client")
+    let rc = client_command()
         .arg("https://localhost:1338")
         .arg("examples/sample.pem")
         .output()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,27 +4,21 @@ use std::process::Command;
 use std::thread;
 use std::time;
 
-fn target_dir() -> PathBuf {
-    env::var("CARGO_TARGET_DIR")
-        .unwrap_or_else(|_| "target".to_string())
-        .into()
-}
-
 fn examples_dir() -> PathBuf {
-    target_dir()
+    let target_dir: PathBuf = env::var("CARGO_TARGET_DIR")
+        .unwrap_or_else(|_| "target".to_string())
+        .into();
+    target_dir
         .join("debug")
         .join("examples")
 }
 
 fn server_command() -> Command {
-    let server_bin_path = examples_dir().join("server");
-    Command::new(server_bin_path)
+    Command::new(examples_dir().join("server"))
 }
 
 fn client_command() -> Command {
-    let client_bin_path = examples_dir().join("client");
-    println!("client_bin_path: {:?}", client_bin_path);
-    Command::new(client_bin_path)
+    Command::new(examples_dir().join("client"))
 }
 
 #[test]


### PR DESCRIPTION
Tests don't work if you have a custom `CARGO_TARGET_DIR`