### PR TITLE
Add TLSAcceptor and Builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,7 @@ futures-util = { version = "0.3.1", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
 rustls = { version = "0.21.0", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
-tokio = { version = "1.0", features = [
-    "io-std",
-    "macros",
-    "net",
-    "rt-multi-thread",
-] }
+tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]
 default = ["native-tokio", "http1", "tls12", "logging", "acceptor"]
@@ -40,7 +35,7 @@ http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 webpki-tokio = ["tokio-runtime", "webpki-roots"]
 native-tokio = ["tokio-runtime", "rustls-native-certs"]
-tokio-runtime = ["hyper/runtime"]
+tokio-runtime =  ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,28 @@ rustls = { version = "0.21.0", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.24.0", default-features = false }
 webpki-roots = { version = "0.23", optional = true }
+futures-util = { version = "0.3" }
 
 [dev-dependencies]
 futures-util = { version = "0.3.1", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
 rustls = { version = "0.21.0", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
-tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.0", features = [
+    "io-std",
+    "macros",
+    "net",
+    "rt-multi-thread",
+] }
 
 [features]
-default = ["native-tokio", "http1", "tls12", "logging"]
+default = ["native-tokio", "http1", "tls12", "logging", "acceptor"]
+acceptor = ["hyper/server", "tokio-runtime"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 webpki-tokio = ["tokio-runtime", "webpki-roots"]
 native-tokio = ["tokio-runtime", "rustls-native-certs"]
-tokio-runtime =  ["hyper/runtime"]
+tokio-runtime = ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ required-features = ["native-tokio", "http1"]
 [[example]]
 name = "server"
 path = "examples/server.rs"
-required-features = ["tokio-runtime"]
+required-features = ["tokio-runtime", "acceptor"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,20 +4,18 @@
 //! Certificate and private key are hardcoded to sample files.
 //! hyper will automatically use HTTP/2 if a client starts talking HTTP/2,
 //! otherwise HTTP/1.1 will be used.
-use core::task::{Context, Poll};
-use futures_util::ready;
-use hyper::server::accept::Accept;
-use hyper::server::conn::{AddrIncoming, AddrStream};
+
+use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
 use std::vec::Vec;
-use std::{env, fs, io, sync};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio_rustls::rustls::ServerConfig;
+use std::{env, fs, io};
 
+#[cfg(not(feature = "acceptor"))]
+fn main() {
+    println!("This example requires the `acceptor` feature");
+}
+#[cfg(feature = "acceptor")]
 fn main() {
     // Serve an echo service over HTTPS, with proper error handling.
     if let Err(e) = run_server() {
@@ -30,8 +28,10 @@ fn error(err: String) -> io::Error {
     io::Error::new(io::ErrorKind::Other, err)
 }
 
+#[cfg(feature = "acceptor")]
 #[tokio::main]
 async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use hyper_rustls::TlsAcceptor;
     // First parameter is port number (optional, defaults to 1337)
     let port = match env::args().nth(1) {
         Some(ref p) => p.to_owned(),
@@ -39,137 +39,26 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     };
     let addr = format!("127.0.0.1:{}", port).parse()?;
 
+    // Load public certificate.
+    let certs = load_certs("examples/sample.pem")?;
+    // Load private key.
+    let key = load_private_key("examples/sample.rsa")?;
     // Build TLS configuration.
-    let tls_cfg = {
-        // Load public certificate.
-        let certs = load_certs("examples/sample.pem")?;
-        // Load private key.
-        let key = load_private_key("examples/sample.rsa")?;
-        // Do not use client certificate authentication.
-        let mut cfg = rustls::ServerConfig::builder()
-            .with_safe_defaults()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
-            .map_err(|e| error(format!("{}", e)))?;
-        // Configure ALPN to accept HTTP/2, HTTP/1.1, and HTTP/1.0 in that order.
-        cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"http/1.0".to_vec()];
-        sync::Arc::new(cfg)
-    };
 
     // Create a TCP listener via tokio.
     let incoming = AddrIncoming::bind(&addr)?;
+    let acceptor = TlsAcceptor::builder()
+        .with_single_cert(certs, key)
+        .map_err(|e| error(format!("{}", e)))?
+        .with_http_alpn()
+        .with_incoming(incoming);
     let service = make_service_fn(|_| async { Ok::<_, io::Error>(service_fn(echo)) });
-    let server = Server::builder(TlsAcceptor::new(tls_cfg, incoming)).serve(service);
+    let server = Server::builder(acceptor).serve(service);
 
     // Run the future, keep going until an error occurs.
     println!("Starting to serve on https://{}.", addr);
     server.await?;
     Ok(())
-}
-
-enum State {
-    Handshaking(tokio_rustls::Accept<AddrStream>),
-    Streaming(tokio_rustls::server::TlsStream<AddrStream>),
-}
-
-// tokio_rustls::server::TlsStream doesn't expose constructor methods,
-// so we have to TlsAcceptor::accept and handshake to have access to it
-// TlsStream implements AsyncRead/AsyncWrite handshaking tokio_rustls::Accept first
-pub struct TlsStream {
-    state: State,
-}
-
-impl TlsStream {
-    fn new(stream: AddrStream, config: Arc<ServerConfig>) -> TlsStream {
-        let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
-        TlsStream {
-            state: State::Handshaking(accept),
-        }
-    }
-}
-
-impl AsyncRead for TlsStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut ReadBuf,
-    ) -> Poll<io::Result<()>> {
-        let pin = self.get_mut();
-        match pin.state {
-            State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
-                Ok(mut stream) => {
-                    let result = Pin::new(&mut stream).poll_read(cx, buf);
-                    pin.state = State::Streaming(stream);
-                    result
-                }
-                Err(err) => Poll::Ready(Err(err)),
-            },
-            State::Streaming(ref mut stream) => Pin::new(stream).poll_read(cx, buf),
-        }
-    }
-}
-
-impl AsyncWrite for TlsStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        let pin = self.get_mut();
-        match pin.state {
-            State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
-                Ok(mut stream) => {
-                    let result = Pin::new(&mut stream).poll_write(cx, buf);
-                    pin.state = State::Streaming(stream);
-                    result
-                }
-                Err(err) => Poll::Ready(Err(err)),
-            },
-            State::Streaming(ref mut stream) => Pin::new(stream).poll_write(cx, buf),
-        }
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match self.state {
-            State::Handshaking(_) => Poll::Ready(Ok(())),
-            State::Streaming(ref mut stream) => Pin::new(stream).poll_flush(cx),
-        }
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match self.state {
-            State::Handshaking(_) => Poll::Ready(Ok(())),
-            State::Streaming(ref mut stream) => Pin::new(stream).poll_shutdown(cx),
-        }
-    }
-}
-
-pub struct TlsAcceptor {
-    config: Arc<ServerConfig>,
-    incoming: AddrIncoming,
-}
-
-impl TlsAcceptor {
-    pub fn new(config: Arc<ServerConfig>, incoming: AddrIncoming) -> TlsAcceptor {
-        TlsAcceptor { config, incoming }
-    }
-}
-
-impl Accept for TlsAcceptor {
-    type Conn = TlsStream;
-    type Error = io::Error;
-
-    fn poll_accept(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
-        let pin = self.get_mut();
-        match ready!(Pin::new(&mut pin.incoming).poll_accept(cx)) {
-            Some(Ok(sock)) => Poll::Ready(Some(Ok(TlsStream::new(sock, pin.config.clone())))),
-            Some(Err(e)) => Poll::Ready(Some(Err(e))),
-            None => Poll::Ready(None),
-        }
-    }
 }
 
 // Custom echo service, handling two different routes and a

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,11 +7,13 @@
 
 #![cfg(feature = "acceptor")]
 
+use std::vec::Vec;
+use std::{env, fs, io};
+
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
-use std::vec::Vec;
-use std::{env, fs, io};
+use hyper_rustls::TlsAcceptor;
 
 fn main() {
     // Serve an echo service over HTTPS, with proper error handling.
@@ -25,10 +27,8 @@ fn error(err: String) -> io::Error {
     io::Error::new(io::ErrorKind::Other, err)
 }
 
-#[cfg(feature = "acceptor")]
 #[tokio::main]
 async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use hyper_rustls::TlsAcceptor;
     // First parameter is port number (optional, defaults to 1337)
     let port = match env::args().nth(1) {
         Some(ref p) => p.to_owned(),

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,17 +5,14 @@
 //! hyper will automatically use HTTP/2 if a client starts talking HTTP/2,
 //! otherwise HTTP/1.1 will be used.
 
+#![cfg(feature = "acceptor")]
+
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use std::vec::Vec;
 use std::{env, fs, io};
 
-#[cfg(not(feature = "acceptor"))]
-fn main() {
-    println!("This example requires the `acceptor` feature");
-}
-#[cfg(feature = "acceptor")]
 fn main() {
     // Serve an echo service over HTTPS, with proper error handling.
     if let Err(e) = run_server() {
@@ -50,7 +47,7 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let acceptor = TlsAcceptor::builder()
         .with_single_cert(certs, key)
         .map_err(|e| error(format!("{}", e)))?
-        .with_http_alpn()
+        .with_all_versions_alpn()
         .with_incoming(incoming);
     let service = make_service_fn(|_| async { Ok::<_, io::Error>(service_fn(echo)) });
     let server = Server::builder(acceptor).serve(service);

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,14 +1,15 @@
 use core::task::{Context, Poll};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+
 use futures_util::ready;
 use hyper::server::{
     accept::Accept,
     conn::{AddrIncoming, AddrStream},
 };
 use rustls::ServerConfig;
-use std::future::Future;
-use std::io;
-use std::pin::Pin;
-use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 mod builder;

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -23,7 +23,7 @@ enum State {
 
 // tokio_rustls::server::TlsStream doesn't expose constructor methods,
 // so we have to TlsAcceptor::accept and handshake to have access to it
-// TlsStream implements AsyncRead/AsyncWrite handshaking tokio_rustls::Accept first
+// TlsStream implements AsyncRead/AsyncWrite by handshaking with tokio_rustls::Accept first
 pub struct TlsStream {
     state: State,
 }
@@ -99,7 +99,7 @@ pub struct TlsAcceptor {
     incoming: AddrIncoming,
 }
 
-/// A Acceptor for the `https` scheme.
+/// An Acceptor for the `https` scheme.
 impl TlsAcceptor {
     /// Provides a builder for a `TlsAcceptor`.
     pub fn builder() -> AcceptorBuilder<WantsTlsConfig> {

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -12,10 +12,9 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 mod builder;
-
 pub use builder::AcceptorBuilder;
+use builder::WantsTlsConfig;
 
-use self::builder::WantsTlsConfig;
 enum State {
     Handshaking(tokio_rustls::Accept<AddrStream>),
     Streaming(tokio_rustls::server::TlsStream<AddrStream>),

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,0 +1,139 @@
+use core::task::{Context, Poll};
+use futures_util::ready;
+use hyper::server::{
+    accept::Accept,
+    conn::{AddrIncoming, AddrStream},
+};
+use rustls::ServerConfig;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+mod builder;
+
+pub use builder::AcceptorBuilder;
+
+use self::builder::WantsTlsConfig;
+enum State {
+    Handshaking(tokio_rustls::Accept<AddrStream>),
+    Streaming(tokio_rustls::server::TlsStream<AddrStream>),
+}
+
+// tokio_rustls::server::TlsStream doesn't expose constructor methods,
+// so we have to TlsAcceptor::accept and handshake to have access to it
+// TlsStream implements AsyncRead/AsyncWrite handshaking tokio_rustls::Accept first
+pub struct TlsStream {
+    state: State,
+}
+
+impl TlsStream {
+    fn new(stream: AddrStream, config: Arc<ServerConfig>) -> TlsStream {
+        let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
+        TlsStream {
+            state: State::Handshaking(accept),
+        }
+    }
+}
+
+impl AsyncRead for TlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        let pin = self.get_mut();
+        match pin.state {
+            State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
+                Ok(mut stream) => {
+                    let result = Pin::new(&mut stream).poll_read(cx, buf);
+                    pin.state = State::Streaming(stream);
+                    result
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            },
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for TlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let pin = self.get_mut();
+        match pin.state {
+            State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
+                Ok(mut stream) => {
+                    let result = Pin::new(&mut stream).poll_write(cx, buf);
+                    pin.state = State::Streaming(stream);
+                    result
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            },
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.state {
+            State::Handshaking(_) => Poll::Ready(Ok(())),
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.state {
+            State::Handshaking(_) => Poll::Ready(Ok(())),
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+/// A TLS acceptor that can be used with hyper servers.
+pub struct TlsAcceptor {
+    config: Arc<ServerConfig>,
+    incoming: AddrIncoming,
+}
+
+/// A Acceptor for the `https` scheme.
+impl TlsAcceptor {
+    /// Provides a builder for a `TlsAcceptor`.
+    pub fn builder() -> AcceptorBuilder<WantsTlsConfig> {
+        AcceptorBuilder::new()
+    }
+    /// Creates a new `TlsAcceptor` from a `ServerConfig` and an `AddrIncoming`.
+    pub fn new(config: Arc<ServerConfig>, incoming: AddrIncoming) -> TlsAcceptor {
+        TlsAcceptor { config, incoming }
+    }
+}
+
+impl<C, I> From<(C, I)> for TlsAcceptor
+where
+    C: Into<Arc<ServerConfig>>,
+    I: Into<AddrIncoming>,
+{
+    fn from((config, incoming): (C, I)) -> TlsAcceptor {
+        TlsAcceptor::new(config.into(), incoming.into())
+    }
+}
+
+impl Accept for TlsAcceptor {
+    type Conn = TlsStream;
+    type Error = io::Error;
+
+    fn poll_accept(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        let pin = self.get_mut();
+        match ready!(Pin::new(&mut pin.incoming).poll_accept(cx)) {
+            Some(Ok(sock)) => Poll::Ready(Some(Ok(TlsStream::new(sock, pin.config.clone())))),
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            None => Poll::Ready(None),
+        }
+    }
+}

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use hyper::server::conn::AddrIncoming;
+use rustls::ServerConfig;
+
+use super::TlsAcceptor;
+/// Builder for [`TlsAcceptor`]
+pub struct AcceptorBuilder<State>(State);
+
+/// State of a builder that needs a TLS client config next
+pub struct WantsTlsConfig(());
+
+impl AcceptorBuilder<WantsTlsConfig> {
+    /// Creates a new [`AcceptorBuilder`]
+    pub fn new() -> Self {
+        Self(WantsTlsConfig(()))
+    }
+
+    /// Passes a rustls [`ServerConfig`] to configure the TLS connection
+    ///
+    pub fn with_tls_config(self, config: ServerConfig) -> AcceptorBuilder<WantsAlpn> {
+        AcceptorBuilder(WantsAlpn(config))
+    }
+
+    /// Shorthand for using rustls' [safe defaults][with_safe_defaults]
+    /// and [no client auth][with_no_client_auth]
+    ///
+    ///
+    /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
+    /// [with_no_client_auth]: rustls::ConfigBuilder::with_no_client_auth
+    pub fn with_single_cert(
+        self,
+        cert_chain: Vec<rustls::Certificate>,
+        key_der: rustls::PrivateKey,
+    ) -> Result<AcceptorBuilder<WantsAlpn>, rustls::Error> {
+        Ok(AcceptorBuilder(WantsAlpn(
+            ServerConfig::builder()
+                .with_safe_defaults()
+                .with_no_client_auth()
+                .with_single_cert(cert_chain, key_der)?,
+        )))
+    }
+}
+
+impl Default for AcceptorBuilder<WantsTlsConfig> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// State of a builder that needs a incoming address next
+pub struct WantsAlpn(ServerConfig);
+
+impl AcceptorBuilder<WantsAlpn> {
+    /// Configure ALPN accept protocols in order
+    pub fn with_alpn_protocols(
+        mut self,
+        alpn_protocols: Vec<Vec<u8>>,
+    ) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = alpn_protocols;
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accep HTTP/2
+    pub fn with_http2_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"h2".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accep HTTP/1.1
+    pub fn with_http11_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"http/1.1".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
+    pub fn with_http_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+}
+
+/// State of a builder that needs a incoming address next
+pub struct WantsIncoming(ServerConfig);
+impl AcceptorBuilder<WantsIncoming> {
+    /// Passes a [`AddrIncoming`] to configure the TLS connection and
+    /// creates the [`TlsAcceptor`]
+    pub fn with_incoming<I>(self, incoming: I) -> TlsAcceptor
+    where
+        AddrIncoming: From<I>,
+    {
+        TlsAcceptor {
+            config: Arc::new(self.0 .0),
+            incoming: AddrIncoming::from(incoming),
+        }
+    }
+}

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -12,7 +12,7 @@ pub struct WantsTlsConfig(());
 
 impl AcceptorBuilder<WantsTlsConfig> {
     /// Creates a new [`AcceptorBuilder`]
-    pub(super) fn new() -> Self {
+    pub fn new() -> Self {
         Self(WantsTlsConfig(()))
     }
 

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -39,6 +39,12 @@ impl AcceptorBuilder<WantsTlsConfig> {
     }
 }
 
+impl Default for AcceptorBuilder<WantsTlsConfig> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// State of a builder that needs a incoming address next
 pub struct WantsAlpn(ServerConfig);
 
@@ -58,15 +64,21 @@ impl AcceptorBuilder<WantsAlpn> {
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }
 
+    /// Configure ALPN to accept HTTP/1.0
+    pub fn with_http10_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"http/1.0".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
     /// Configure ALPN to accept HTTP/1.1
-    pub fn with_http1_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+    pub fn with_http11_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
         self.0 .0.alpn_protocols = vec![b"http/1.1".to_vec()];
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }
 
-    /// Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
+    /// Configure ALPN to accept HTTP/2, HTTP/1.1, HTTP/1.0 in that order.
     pub fn with_all_versions_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
-        self.0 .0.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        self.0 .0.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"http/1.0".to_vec()];
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }
 }

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -52,13 +52,13 @@ impl AcceptorBuilder<WantsAlpn> {
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }
 
-    /// Configure ALPN to accep HTTP/2
+    /// Configure ALPN to accept HTTP/2
     pub fn with_http2_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
         self.0 .0.alpn_protocols = vec![b"h2".to_vec()];
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }
 
-    /// Configure ALPN to accep HTTP/1.1
+    /// Configure ALPN to accept HTTP/1.1
     pub fn with_http1_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
         self.0 .0.alpn_protocols = vec![b"http/1.1".to_vec()];
         AcceptorBuilder(WantsIncoming(self.0 .0))

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -77,11 +77,10 @@ pub struct WantsIncoming(ServerConfig);
 impl AcceptorBuilder<WantsIncoming> {
     /// Passes a [`AddrIncoming`] to configure the TLS connection and
     /// creates the [`TlsAcceptor`]
-    pub fn with_incoming(self, incoming: impl Into<AddrIncoming>) -> TlsAcceptor {```
-    {
+    pub fn with_incoming(self, incoming: impl Into<AddrIncoming>) -> TlsAcceptor {
         TlsAcceptor {
             config: Arc::new(self.0 .0),
-            incoming: AddrIncoming::from(incoming),
+            incoming: incoming.into(),
         }
     }
 }

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -17,14 +17,11 @@ impl AcceptorBuilder<WantsTlsConfig> {
     }
 
     /// Passes a rustls [`ServerConfig`] to configure the TLS connection
-    ///
     pub fn with_tls_config(self, config: ServerConfig) -> AcceptorBuilder<WantsAlpn> {
         AcceptorBuilder(WantsAlpn(config))
     }
 
-    /// Shorthand for using rustls' [safe defaults][with_safe_defaults]
-    /// and [no client auth][with_no_client_auth]
-    ///
+    /// Use rustls [defaults][with_safe_defaults] without [client authentication][with_no_client_auth]
     ///
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
     /// [with_no_client_auth]: rustls::ConfigBuilder::with_no_client_auth
@@ -76,12 +73,11 @@ impl AcceptorBuilder<WantsAlpn> {
 
 /// State of a builder that needs a incoming address next
 pub struct WantsIncoming(ServerConfig);
+
 impl AcceptorBuilder<WantsIncoming> {
     /// Passes a [`AddrIncoming`] to configure the TLS connection and
     /// creates the [`TlsAcceptor`]
-    pub fn with_incoming<I>(self, incoming: I) -> TlsAcceptor
-    where
-        AddrIncoming: From<I>,
+    pub fn with_incoming(self, incoming: impl Into<AddrIncoming>) -> TlsAcceptor {```
     {
         TlsAcceptor {
             config: Arc::new(self.0 .0),

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -12,7 +12,7 @@ pub struct WantsTlsConfig(());
 
 impl AcceptorBuilder<WantsTlsConfig> {
     /// Creates a new [`AcceptorBuilder`]
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self(WantsTlsConfig(()))
     }
 
@@ -42,12 +42,6 @@ impl AcceptorBuilder<WantsTlsConfig> {
     }
 }
 
-impl Default for AcceptorBuilder<WantsTlsConfig> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// State of a builder that needs a incoming address next
 pub struct WantsAlpn(ServerConfig);
 
@@ -68,13 +62,13 @@ impl AcceptorBuilder<WantsAlpn> {
     }
 
     /// Configure ALPN to accep HTTP/1.1
-    pub fn with_http11_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+    pub fn with_http1_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
         self.0 .0.alpn_protocols = vec![b"http/1.1".to_vec()];
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }
 
     /// Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
-    pub fn with_http_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+    pub fn with_all_versions_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
         self.0 .0.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -40,13 +40,6 @@ impl<T> fmt::Debug for HttpsConnector<T> {
     }
 }
 
-impl HttpsConnector<()> {
-    /// Provides a builder for a `HttpsConnector`.
-    pub fn builder() -> builder::ConnectorBuilder<builder::WantsTlsConfig> {
-        builder::ConnectorBuilder::new()
-    }
-}
-
 impl<H, C> From<(H, C)> for HttpsConnector<H>
 where
     C: Into<Arc<rustls::ClientConfig>>,

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -40,6 +40,13 @@ impl<T> fmt::Debug for HttpsConnector<T> {
     }
 }
 
+impl HttpsConnector<()> {
+    /// Provides a builder for a `HttpsConnector`.
+    pub fn builder() -> builder::ConnectorBuilder<builder::WantsTlsConfig> {
+        builder::ConnectorBuilder::new()
+    }
+}
+
 impl<H, C> From<(H, C)> for HttpsConnector<H>
 where
     C: Into<Arc<rustls::ClientConfig>>,

--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -274,13 +274,11 @@ impl ConnectorBuilder<WantsProtocols3> {
 
 #[cfg(test)]
 mod tests {
-    use super::ConnectorBuilder as HttpsConnectorBuilder;
-
     // Typical usage
     #[test]
     #[cfg(all(feature = "webpki-roots", feature = "http1"))]
     fn test_builder() {
-        let _connector = HttpsConnectorBuilder::new()
+        let _connector = super::ConnectorBuilder::new()
             .with_webpki_roots()
             .https_only()
             .enable_http1()
@@ -297,7 +295,7 @@ mod tests {
             .with_root_certificates(roots)
             .with_no_client_auth();
         config_with_alpn.alpn_protocols = vec![b"fancyprotocol".to_vec()];
-        let _connector = HttpsConnectorBuilder::new()
+        let _connector = super::ConnectorBuilder::new()
             .with_tls_config(config_with_alpn)
             .https_only()
             .enable_http1()
@@ -312,7 +310,7 @@ mod tests {
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();
-        let connector = HttpsConnectorBuilder::new()
+        let connector = super::ConnectorBuilder::new()
             .with_tls_config(tls_config.clone())
             .https_only()
             .enable_http1()
@@ -321,13 +319,13 @@ mod tests {
             .tls_config
             .alpn_protocols
             .is_empty());
-        let connector = HttpsConnectorBuilder::new()
+        let connector = super::ConnectorBuilder::new()
             .with_tls_config(tls_config.clone())
             .https_only()
             .enable_http2()
             .build();
         assert_eq!(&connector.tls_config.alpn_protocols, &[b"h2".to_vec()]);
-        let connector = HttpsConnectorBuilder::new()
+        let connector = super::ConnectorBuilder::new()
             .with_tls_config(tls_config)
             .https_only()
             .enable_http1()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! let mut rt = tokio::runtime::Runtime::new().unwrap();
 //! let url = ("https://hyper.rs").parse().unwrap();
-//! let https = hyper_rustls::HttpsConnector::builder()
+//! let https = hyper_rustls::HttpsConnectorBuilder::new()
 //!     .with_native_roots()
 //!     .https_only()
 //!     .enable_http1()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! A pure-Rust HTTPS connector for [hyper](https://hyper.rs), based on
 //! [Rustls](https://github.com/rustls/rustls).
 //!
-//! ## Example
+//! ## Example Client
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1"))]
@@ -12,7 +12,7 @@
 //!
 //! let mut rt = tokio::runtime::Runtime::new().unwrap();
 //! let url = ("https://hyper.rs").parse().unwrap();
-//! let https = hyper_rustls::HttpsConnectorBuilder::new()
+//! let https = hyper_rustls::HttpsConnector::builder()
 //!     .with_native_roots()
 //!     .https_only()
 //!     .enable_http1()
@@ -26,10 +26,57 @@
 //! # #[cfg(not(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1")))]
 //! # fn main() {}
 //! ```
+//!
+//! ## Example server
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1", feature = "acceptor"))]
+//! # fn main() {
+//! use hyper::server::conn::AddrIncoming;
+//! use hyper::service::{make_service_fn, service_fn};
+//! use hyper::{Body, Method, Request, Response, Server, StatusCode};
+//! use hyper_rustls::TlsAcceptor;
+//! use std::io;
+//! use std::fs::File;
+//!
+//! let mut rt = tokio::runtime::Runtime::new().unwrap();
+//! let addr = "127.0.0.1:1337".parse().unwrap();
+//! // Load public certificate.
+//! let certfile = File::open("examples/sample.pem").unwrap();
+//! let mut reader = io::BufReader::new(certfile);
+//! // Load and return certificate.
+//! let certs = rustls_pemfile::certs(&mut reader).unwrap();
+//! let certs =certs.into_iter().map(rustls::Certificate).collect();
+//! // Load private key. (see `examples/server.rs`)
+//! let keyfile = File::open("examples/sample.rsa").unwrap();
+//! let mut reader = io::BufReader::new(keyfile);
+//! // Load and return a single private key.
+//! let keys = rustls_pemfile::rsa_private_keys(&mut reader).unwrap();
+//! let key = rustls::PrivateKey(keys[0].clone());
+//! let https = hyper_rustls::HttpsConnectorBuilder::new()
+//!     .with_native_roots()
+//!     .https_only()
+//!     .enable_http1()
+//!     .build();
+//!
+//! let incoming = AddrIncoming::bind(&addr).unwrap();
+//! let acceptor = TlsAcceptor::builder()
+//!     .with_single_cert(certs, key).unwrap()
+//!     .with_http_alpn()
+//!     .with_incoming(incoming);
+//! let service = make_service_fn(|_| async { Ok::<_, io::Error>(service_fn(|_req|async {Ok::<_, io::Error>(Response::new(Body::empty()))})) });
+//! let server = Server::builder(acceptor).serve(service);
+//! // server.await.unwrap();
+//! # }
+//! # #[cfg(not(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1")))]
+//! # fn main() {}
+//! ```
 
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "acceptor")]
+mod acceptor;
 mod config;
 mod connector;
 mod stream;
@@ -46,6 +93,8 @@ mod log {
     pub(crate) use {debug, trace};
 }
 
+#[cfg(feature = "acceptor")]
+pub use crate::acceptor::{AcceptorBuilder, TlsAcceptor};
 pub use crate::config::ConfigBuilderExt;
 pub use crate::connector::builder::ConnectorBuilder as HttpsConnectorBuilder;
 pub use crate::connector::HttpsConnector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,15 +41,23 @@
 //!
 //! let mut rt = tokio::runtime::Runtime::new().unwrap();
 //! let addr = "127.0.0.1:1337".parse().unwrap();
+//!
+//!
 //! // Load public certificate.
 //! let certfile = File::open("examples/sample.pem").unwrap();
 //! let mut reader = io::BufReader::new(certfile);
+//!
+//!
 //! // Load and return certificate.
 //! let certs = rustls_pemfile::certs(&mut reader).unwrap();
 //! let certs =certs.into_iter().map(rustls::Certificate).collect();
+//!
+//!
 //! // Load private key. (see `examples/server.rs`)
 //! let keyfile = File::open("examples/sample.rsa").unwrap();
 //! let mut reader = io::BufReader::new(keyfile);
+//!
+//!
 //! // Load and return a single private key.
 //! let keys = rustls_pemfile::rsa_private_keys(&mut reader).unwrap();
 //! let key = rustls::PrivateKey(keys[0].clone());
@@ -62,7 +70,7 @@
 //! let incoming = AddrIncoming::bind(&addr).unwrap();
 //! let acceptor = TlsAcceptor::builder()
 //!     .with_single_cert(certs, key).unwrap()
-//!     .with_http_alpn()
+//!     .with_all_versions_alpn()
 //!     .with_incoming(incoming);
 //! let service = make_service_fn(|_| async { Ok::<_, io::Error>(service_fn(|_req|async {Ok::<_, io::Error>(Response::new(Body::empty()))})) });
 //! let server = Server::builder(acceptor).serve(service);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! A pure-Rust HTTPS connector for [hyper](https://hyper.rs), based on
 //! [Rustls](https://github.com/rustls/rustls).
 //!
-//! ## Example Client
+//! ## Example client
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1"))]
@@ -42,21 +42,17 @@
 //! let mut rt = tokio::runtime::Runtime::new().unwrap();
 //! let addr = "127.0.0.1:1337".parse().unwrap();
 //!
-//!
 //! // Load public certificate.
 //! let certfile = File::open("examples/sample.pem").unwrap();
 //! let mut reader = io::BufReader::new(certfile);
 //!
-//!
 //! // Load and return certificate.
 //! let certs = rustls_pemfile::certs(&mut reader).unwrap();
-//! let certs =certs.into_iter().map(rustls::Certificate).collect();
-//!
+//! let certs = certs.into_iter().map(rustls::Certificate).collect();
 //!
 //! // Load private key. (see `examples/server.rs`)
 //! let keyfile = File::open("examples/sample.rsa").unwrap();
 //! let mut reader = io::BufReader::new(keyfile);
-//!
 //!
 //! // Load and return a single private key.
 //! let keys = rustls_pemfile::rsa_private_keys(&mut reader).unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -42,6 +42,7 @@ fn client() {
     assert!(rc.status.success());
 }
 
+#[cfg(feature = "acceptor")]
 #[test]
 fn server() {
     let mut srv = server_command()


### PR DESCRIPTION
TLSAcceptor, including a builder, also adds a `builder()` method to the Connector for convenience.