### PR TITLE
Add `HttpsConnector::https_only` for compatibility with `hyper_tls`

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -23,6 +23,15 @@ pub struct HttpsConnector<T> {
     override_server_name: Option<String>,
 }
 
+impl<T> HttpsConnector<T> {
+    /// Force the use of HTTPS when connecting.
+    ///
+    /// If a URL is not `https` when connecting, an error is returned.
+    pub fn https_only(&mut self, enable: bool) {
+        self.force_https = enable;
+    }
+}
+
 impl<T> fmt::Debug for HttpsConnector<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("HttpsConnector")

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -27,8 +27,8 @@ impl<T> HttpsConnector<T> {
     /// Force the use of HTTPS when connecting.
     ///
     /// If a URL is not `https` when connecting, an error is returned.
-    pub fn https_only(&mut self, enable: bool) {
-        self.force_https = enable;
+    pub fn enforce_https(&mut self) {
+        self.force_https = true;
     }
 }
 


### PR DESCRIPTION
## Description
It's convenient to be able to configure this flag after building the `HttpsConnector`, and [`hyper_tls` has this functionality](https://docs.rs/hyper-tls/latest/hyper_tls/struct.HttpsConnector.html#method.https_only) so this is nice for compatibility.

See https://github.com/awslabs/smithy-rs/pull/2316#discussion_r1097744060 for motivation.