### PR TITLE
fix: allow example server http/1.0 ALPN.

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -51,8 +51,8 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             .with_no_client_auth()
             .with_single_cert(certs, key)
             .map_err(|e| error(format!("{}", e)))?;
-        // Configure ALPN to accept HTTP/2, HTTP/1.1 in that order.
-        cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        // Configure ALPN to accept HTTP/2, HTTP/1.1, and HTTP/1.0 in that order.
+        cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"http/1.0".to_vec()];
         sync::Arc::new(cfg)
     };
 


### PR DESCRIPTION
## Background

Prior to this branch the `example/server.rs` code built a Rustls `ServerConfig` that configured the `alpn_protocols` to accept HTTP/2 and HTTP/1.1. Notably, the protocol list did **not** include HTTP/1.0: https://github.com/rustls/hyper-rustls/blob/d7fa80318a96e356e4a41dd0964498cae340fa69/examples/server.rs#L54-L55

This should have been uncovered by the `tests/test.rs` integration tests explicitly providing `--http1.0` in the test `curl` invocations: https://github.com/rustls/hyper-rustls/blob/d7fa80318a96e356e4a41dd0964498cae340fa69/tests/tests.rs#L45

Unfortunately it was hidden by an upstream bug in curl! Prior to v7.88.0 [curl would send the HTTP1.1 ALPN ID even when `--http1.0` was specified](https://github.com/curl/curl/commit/df856cb5c94665c9083dc8be5bb02392d841cc1e), and so our example server would work even without accepting HTTP1.0 ALPN. This was fixed in v7.88.0 and so our MacOS runners began to exhibit server test failures when they attempted to negotiate HTTP/1.0 ALPN with a server that didn't support it.

## Fix

This commit updates the example server code to accept HTTP/1.0 ALPN, which in turn fixes the unit tests when run with Curl v7.88.0+. This should also help with other clients that didn't exhibit the same bug as curl did.