### PR TITLE
small integration test improvements.

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -62,6 +62,12 @@ fn server() {
     srv.kill().unwrap();
 
     if !output.status.success() {
+        let version_stdout = Command::new("curl")
+            .arg("--version")
+            .output()
+            .expect("cannot run curl to collect --version")
+            .stdout;
+        println!("curl version: {}", String::from_utf8_lossy(&version_stdout));
         println!("curl stderr:\n{}", String::from_utf8_lossy(&output.stderr));
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -55,15 +55,17 @@ fn server() {
     let output = Command::new("curl")
         .arg("--insecure")
         .arg("--http1.0")
-        .arg("--silent")
         .arg(format!("https://{}", addr))
         .output()
         .expect("cannot run curl");
 
     srv.kill().unwrap();
 
-    println!("client output: {:?}", output.stdout);
-    assert_eq!(output.stdout, b"Try POST /echo\n");
+    if !output.status.success() {
+        println!("curl stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    assert_eq!(String::from_utf8_lossy(&*output.stdout), "Try POST /echo\n");
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
@@ -21,6 +22,16 @@ fn client_command() -> Command {
     Command::new(examples_dir().join("client"))
 }
 
+fn wait_for_server(addr: &str) {
+    for i in 0..10 {
+        if let Ok(_) = TcpStream::connect(addr) {
+            return;
+        }
+        thread::sleep(time::Duration::from_millis(i * 100));
+    }
+    panic!("failed to connect to {:?} after 10 tries", addr);
+}
+
 #[test]
 fn client() {
     let rc = client_command()
@@ -38,13 +49,14 @@ fn server() {
         .spawn()
         .expect("cannot run server example");
 
-    thread::sleep(time::Duration::from_secs(1));
+    let addr = "localhost:1337";
+    wait_for_server(addr);
 
     let output = Command::new("curl")
         .arg("--insecure")
         .arg("--http1.0")
         .arg("--silent")
-        .arg("https://localhost:1337")
+        .arg(format!("https://{}", addr))
         .output()
         .expect("cannot run curl");
 
@@ -61,10 +73,11 @@ fn custom_ca_store() {
         .spawn()
         .expect("cannot run server example");
 
-    thread::sleep(time::Duration::from_secs(1));
+    let addr = "localhost:1338";
+    wait_for_server(addr);
 
     let rc = client_command()
-        .arg("https://localhost:1338")
+        .arg(format!("https://{}", addr))
         .arg("examples/sample.pem")
         .output()
         .expect("cannot run client example");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -60,10 +60,10 @@ fn server() {
         .output()
         .expect("cannot run curl");
 
+    srv.kill().unwrap();
+
     println!("client output: {:?}", output.stdout);
     assert_eq!(output.stdout, b"Try POST /echo\n");
-
-    srv.kill().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Description

This branch adds some quality of life improvements to the integration tests that I found helpful while debugging https://github.com/rustls/hyper-rustls/pull/193

Their effect is perhaps best observed comparing the output of the test when the fix for #193 is reverted.

<details>
<summary>Without this branch's changes:</summary>

```
[nix-shell:~/Code/Rust/hyper-rustls]$ git rev-parse HEAD
d7fa80318a96e356e4a41dd0964498cae340fa6

[nix-shell:~/Code/Rust/hyper-rustls]$ cargo test
   Compiling hyper-rustls v0.23.2 (/home/daniel/Code/Rust/hyper-rustls)
    Finished test [unoptimized + debuginfo] target(s) in 1.47s
     Running unittests src/lib.rs (target/debug/deps/hyper_rustls-4f585a9d68b5c42a)

running 1 test
test connector::builder::tests::test_reject_predefined_alpn - should panic ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/tests.rs (target/debug/deps/tests-ca3314d7ee35e116)

running 3 tests
Starting to serve on https://127.0.0.1:1338.
Starting to serve on https://127.0.0.1:1337.
test client ... ok
test server ... FAILED
test custom_ca_store ... ok

failures:

---- server stdout ----
client output: []
thread 'server' panicked at 'assertion failed: `(left == right)`
  left: `[]`,
 right: `[84, 114, 121, 32, 80, 79, 83, 84, 32, 47, 101, 99, 104, 111, 10]`', tests/tests.rs:52:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    server

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.01s

error: test failed, to rerun pass '--test tests'

[nix-shell:~/Code/Rust/hyper-rustls]$ ps aux | grep [1]337
daniel   1303117  0.0  0.0 1362672 6936 pts/1    Sl   12:34   0:00 target/debug/examples/server 1337
```
</details>

<details>
<summary>With this branch's changes:</summary>

```
[nix-shell:~/Code/Rust/hyper-rustls]$ git rev-parse HEAD
988d6aeb1e8604a726e3cafbcabba993682273d4

[nix-shell:~/Code/Rust/hyper-rustls]$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/hyper_rustls-4f585a9d68b5c42a)

running 1 test
test connector::builder::tests::test_reject_predefined_alpn - should panic ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/tests.rs (target/debug/deps/tests-ca3314d7ee35e116)

running 3 tests
Starting to serve on https://127.0.0.1:1338.
Starting to serve on https://127.0.0.1:1337.
test custom_ca_store ... ok
test server ... FAILED
test client ... ok

failures:

---- server stdout ----
curl version: curl 7.88.0 (x86_64-pc-linux-gnu) libcurl/7.88.0 OpenSSL/3.0.8 zlib/1.2.13 brotli/1.0.9 zstd/1.5.4 libidn2/2.3.2 libssh2/1.10.0 nghttp2/1.51.0
Release-Date: 2023-02-15
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd

curl stderr:
curl: (35) OpenSSL/3.0.8: error:0A000460:SSL routines::reason(1120)

thread 'server' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"Try POST /echo\n"`', tests/tests.rs:78:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    server

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s

error: test failed, to rerun pass '--test tests'

[nix-shell:~/Code/Rust/hyper-rustls]$ ps aux | grep [1]337
```

</details>

In the updated version:
* We show the stderr with the root cause of the failure (`error:0A000460:SSL routines::reason(1120)`)
* We show the curl version (7.88.0)
* We show the expected content as a string not a byte slice.
* We don't leak the server process.

### chore: avoid fixed sleep in integration tests. - 9531fbc1dc9b9c6666d3023e31aff9a1f02f9d91
Prior to this commit the `tests/tests.rs` integration tests had an unconditional 1 second sleep waiting for a server to become available. This is slightly problematic:

* Waiting a full second if the server becomes available sooner is unnecessarily slow.
* Conversely, we can't be sure the server is available after the 1s sleep.

This commit replaces the sleeps with a loop of up to 10 iterations that tries to connect to the server port. If any iteration succeeds we return immediately to avoid unnecessary waiting. If an iteration fails, we wait longer, increasing the duration each time we wait (up to a maximum of 10 iterations).

### fix: kill server before asserting on output. - 2b7da581f58e4724e31630b58fea739cc9e5fc4e
Prior to this commit the `server()` test would call `assert_eq!` to assert on client output matching expected _before_ calling `srv.kill()` on the `Child` spawned by `server_command()`.

The upstream [rustdocs for `std.process.Child`](https://doc.rust-lang.org/std/process/struct.Child.html) mention:
> There is no implementation of Drop for child processes, so if you do not ensure the Child has exited then it will continue to run, even after the Child handle to the child process has gone out of scope.

The net result is that if the assertion in `server()` fails, we leave a running server instance behind. This manifests as a port conflict when re-running the test without first killing the orphan.

This commit moves the `srv.kill()` call to before the `assert_eq`. This avoids leaking the server process if the assertion fails.

### chore: improve server integration test output. - fd8a11152e82ea55aa61a92fd06e2cbae54a3f50
This commit adds a few quality of life improvements to the server integration test:

1. The `--silent` curl arg is removed so that we can get diagnostic info from curl on stderr in the event of a failure. Our test only asserts on stdout content, which remains unaffected by this change.
2. If the `curl` command invocation status isn't success, we print the stderr content enabled by not using `--silent`. This will provide more diagnostic context to investigate the failure.
3. The `assert_eq` is changed to assert on a string value created from stdout instead of raw bytes. This is easier for humans to diff in the test output compared to a slice of byte values.

Combined these changes should make it easier to diagnose future test failures without needing to iterate in CI.

### chore: output curl version in server test failure. - ffa7677285ff1758f31e6dbc04118b0bde9d43f7
In the event the `server()` integration test fails it's helpful to know the version of `curl` that was used. This commit includes this
information when the `curl` client invocation returns a non-zero status code.