### PR TITLE
CI: update workflow actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
             rust: stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,9 @@ jobs:
           persist-credentials: false
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: cargo check (default features)
         run: cargo check --all-targets
@@ -79,11 +78,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          default: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo doc (all features)
         run: cargo doc --all-features --no-deps
@@ -99,17 +94,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          default: true
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -120,13 +109,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          default: true
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
+      - run: cargo clippy --all-features -- --deny warnings


### PR DESCRIPTION

To address [a pending deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), and to remove CI warnings this branch brings the CI improvements that landed on the `rustls/rustls` repo in https://github.com/rustls/rustls/pull/1214 to this repo.

### CI: configure Dependabot to monitor GitHub actions.
This commit updates the existing `.github/dependabot.yml` config that monitors Cargo dependencies to also monitor GitHub actions (on a weekly cadence).

### CI: actions/checkout@v2 -> v3.
Does what it says on the tin.

### CI: replace actions-rs w/ dtolnay/rust-toolchain.
This commit replaces the `actions-rs/toolchain` action with `dtolnay/rust-toolchain`. The former is [no longer maintained](https://github.com/actions-rs/toolchain/issues/216).

Usages of `actions-rs/cargo` are replaced with direct invocation of the relevant tooling installed by `dtolnay/rust-toolchain`. 