### PR TITLE
CI: replace ubuntu 18.04 w/ 20.04.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - beta
           - nightly
           - 1.57
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:
           - os: macos-latest


### PR DESCRIPTION
Quick follow-up to #196.

The Build+Test matrix job of the GitHub actions workflow was using Ubuntu 18.04, which is deprecated.

This commit replaces it with Ubuntu 20.04, the oldest supported Ubuntu release available in GitHub actions at the time of writing.

The other workflow task are using `ubuntu-latest` and do not need updating at this time.