### PR TITLE
hyper-rustls v0.24.0 w/ rustls 0.21.0 + tokio-rustls 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.0"
 edition = "2021"
 rust-version = "1.57"
 license = "Apache-2.0/ISC/MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,15 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
-rustls = { version = "0.20.1", default-features = false }
+rustls = { version = "0.21.0", default-features = false }
 tokio = "1.0"
-tokio-rustls = { version = "0.23", default-features = false }
-webpki-roots = { version = "0.22", optional = true }
+tokio-rustls = { version = "0.24.0", default-features = false }
+webpki-roots = { version = "0.23", optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3.1", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
-rustls = { version = "0.20.1", default-features = false, features = ["tls12"] }
+rustls = { version = "0.21.0", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 


### PR DESCRIPTION
## Description

This branch updates hyper-rustls to use a patch to track the yet-to-be-released 0.21.0 rustls work, both as a direct dependency and through an upgrade to tokio-rustls v0.24.0. 

## Remaining work

- [X] wait for https://github.com/tokio-rs/tls/pull/137 to be merged
- [x] wait for tokio-rustls v0.24.0 to be published to crates.io
- [x] remove Cargo.toml patch for tokio-rustls
- [ ] get PR approved
- [ ] publish 0.24.0

