### PR TITLE
ci: Ubuntu 18.04 -> 20.04 for doc tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
   docs:
     name: Check for documentation errors
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
The Ubuntu 18.04 runner type has been removed after a deprecation period. Without this change the "Check for documentation errors" tasks remain stuck in a queued state waiting for runners that will never appear.