### PR TITLE
Disable unnecessary default features from futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,9 @@ rustls = { version = "0.21.0", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.24.0", default-features = false }
 webpki-roots = { version = "0.24", optional = true }
-futures-util = { version = "0.3" }
+futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
-futures-util = { version = "0.3.1", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
 rustls = { version = "0.21.0", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"


### PR DESCRIPTION
futures-util recently grew some more dependencies (via futures-macros) which we don't need here.