### PR TITLE
deps: update webpki-roots v0.24 -> 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustls-native-certs = { version = "0.6", optional = true }
 rustls = { version = "0.21.0", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.24.0", default-features = false }
-webpki-roots = { version = "0.24", optional = true }
+webpki-roots = { version = "0.25", optional = true }
 futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,6 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
         let mut roots = rustls::RootCertStore::empty();
         roots.add_server_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
-                .0
                 .iter()
                 .map(|ta| {
                     rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(


### PR DESCRIPTION
This commit updates the optional `webpki-roots` dependency from v0.24 to v0.25.

One breaking change is addressed in `src/config.rs`.

Replaces https://github.com/rustls/hyper-rustls/pull/214