### PR TITLE
Make TlsStream public and remote_addr accessible

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,7 +1,7 @@
 use core::task::{Context, Poll};
-use std::net::SocketAddr;
 use std::future::Future;
 use std::io;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -27,7 +27,7 @@ enum State {
 // TlsStream implements AsyncRead/AsyncWrite by handshaking with tokio_rustls::Accept first
 pub struct TlsStream {
     state: State,
-    _remote_addr:SocketAddr
+    _remote_addr: SocketAddr,
 }
 
 impl TlsStream {
@@ -36,10 +36,10 @@ impl TlsStream {
         let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
         TlsStream {
             state: State::Handshaking(accept),
-            _remote_addr: remote_addr
+            _remote_addr: remote_addr,
         }
     }
-    
+
     pub fn remote_addr(&self) -> SocketAddr {
         self._remote_addr
     }

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,4 +1,5 @@
 use core::task::{Context, Poll};
+use std::net::SocketAddr;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -26,14 +27,21 @@ enum State {
 // TlsStream implements AsyncRead/AsyncWrite by handshaking with tokio_rustls::Accept first
 pub struct TlsStream {
     state: State,
+    _remote_addr:SocketAddr
 }
 
 impl TlsStream {
     fn new(stream: AddrStream, config: Arc<ServerConfig>) -> TlsStream {
+        let remote_addr = stream.remote_addr();
         let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
         TlsStream {
             state: State::Handshaking(accept),
+            _remote_addr: remote_addr
         }
+    }
+    
+    pub fn remote_addr(&self) -> SocketAddr {
+        self._remote_addr
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ mod log {
 }
 
 #[cfg(feature = "acceptor")]
-pub use crate::acceptor::{AcceptorBuilder, TlsAcceptor};
+pub use crate::acceptor::{AcceptorBuilder, TlsAcceptor, TlsStream};
 pub use crate::config::ConfigBuilderExt;
 pub use crate::connector::builder::ConnectorBuilder as HttpsConnectorBuilder;
 pub use crate::connector::HttpsConnector;


### PR DESCRIPTION
Make TlsStream public and remote_addr accessible - useful if access to the remote address is required in make_service_fn, service_fn or connection/request handlers:

```rust
let make_svc = make_service_fn(|stream:&TlsStream| {
    let remote_addr = stream.remote_addr();
    async move {
        Ok::<_, io::Error>(service_fn(move |req| {
            handle_connection(req, remote_addr)
    }))
}
```