### PR TITLE
Track the latest changes from upstream rustls and tokio-rustls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             rust: stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install rust toolchain
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install rust toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.25.0-alpha.1"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"
@@ -29,7 +29,7 @@ rustls-pemfile = "=2.0.0-alpha.1"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]
-default = ["native-tokio", "http1", "tls12", "logging", "acceptor", "ring"]
+default = ["native-tokio", "http1", "tls12", "logging", "acceptor"]
 acceptor = ["hyper/server", "tokio-runtime"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ rustls-native-certs = { version = "0.6", optional = true }
 rustls = { version = "0.22.0-alpha.3", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.24.1", default-features = false }
-webpki-roots = { version = "0.25", optional = true }
+webpki-roots = { version = "0.26.0-alpha.1", optional = true }
 futures-util = { version = "0.3", default-features = false }
-pki-types = { package = "rustls-pki-types", version = "0.2.1", optional = true }
+pki-types = { package = "rustls-pki-types", version = "0.2.1" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
@@ -38,7 +38,7 @@ native-tokio = ["tokio-runtime", "rustls-native-certs"]
 tokio-runtime =  ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
-ring = ["rustls/ring", "pki-types"]
+ring = ["rustls/ring"]
 
 [[example]]
 name = "client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "=0.7.0-alpha.1", optional = true }
 rustls = { version = "=0.22.0-alpha.4", default-features = false }
 tokio = "1.0"
-tokio-rustls = { version = "=0.25.0-alpha.1", default-features = false }
+tokio-rustls = { version = "=0.25.0-alpha.2", default-features = false }
 webpki-roots = { version = "=0.26.0-alpha.1", optional = true }
 futures-util = { version = "0.3", default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.1" }
@@ -56,5 +56,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
 rustls-native-certs = { git = 'https://github.com/rustls/rustls-native-certs' }
-tokio-rustls = { git = 'https://github.com/stevefan1999-personal/tokio-rustls', branch = "patch-1" }
+tokio-rustls = { git = 'https://github.com/rustls/tokio-rustls' }
 rustls-pemfile = { git = 'https://github.com/rustls/pemfile' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ documentation = "https://docs.rs/hyper-rustls/"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
-rustls-native-certs = { version = "0.6", optional = true }
+rustls-native-certs = { version = "0.7.0-alpha.0", optional = true }
 rustls = { version = "0.22.0-alpha.3", default-features = false }
 tokio = "1.0"
-tokio-rustls = { version = "0.24.1", default-features = false }
+tokio-rustls = { version = "0.25.0-alpha.1", default-features = false }
 webpki-roots = { version = "0.26.0-alpha.1", optional = true }
 futures-util = { version = "0.3", default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.1" }
@@ -25,7 +25,7 @@ pki-types = { package = "rustls-pki-types", version = "0.2.1" }
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
 rustls = { version = "0.22.0-alpha.3", default-features = false, features = ["tls12"] }
-rustls-pemfile = "1.0.0"
+rustls-pemfile = "2.0.0-alpha.1"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]
@@ -55,4 +55,5 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
+rustls-native-certs = { git = 'https://github.com/rustls/rustls-native-certs' }
 tokio-rustls = { git = 'https://github.com/rustls/tokio-rustls' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "=0.7.0-alpha.1", optional = true }
-rustls = { version = "=0.22.0-alpha.3", default-features = false }
+rustls = { version = "=0.22.0-alpha.4", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "=0.25.0-alpha.1", default-features = false }
 webpki-roots = { version = "=0.26.0-alpha.1", optional = true }
@@ -24,7 +24,7 @@ pki-types = { package = "rustls-pki-types", version = "0.2.1" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { version = "=0.22.0-alpha.3", default-features = false, features = ["tls12"] }
+rustls = { version = "=0.22.0-alpha.4", default-features = false, features = ["tls12"] }
 rustls-pemfile = "=2.0.0-alpha.1"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
@@ -56,5 +56,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
 rustls-native-certs = { git = 'https://github.com/rustls/rustls-native-certs' }
-tokio-rustls = { git = 'https://github.com/rustls/tokio-rustls' }
+tokio-rustls = { git = 'https://github.com/stevefan1999-personal/tokio-rustls', branch = "patch-1" }
 rustls-pemfile = { git = 'https://github.com/rustls/pemfile' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,22 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
-rustls = { git = "https://github.com/rustls/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["webpki", "dangerous_configuration"] }
+rustls = { git = "https://github.com/stevefan1999-personal/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["dangerous_configuration"] }
 tokio = "1.0"
 tokio-rustls = { git = "https://github.com/stevefan1999-personal/tokio-rustls", branch = "part-4-patch", version = "0.24.0", default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 futures-util = { version = "0.3", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.102.0-alpha.2", default-features = false, features = ["alloc", "std"] }
-pki-types = { package = "rustls-pki-types", version = "0.2.0" }
+webpki = { package = "rustls-webpki", version = "0.102.0-alpha.3", default-features = false }
+pki-types = { package = "rustls-pki-types", version = "0.2.1", default-features = false }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { git = "https://github.com/rustls/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["webpki", "tls12"] }
+rustls = { git = "https://github.com/stevefan1999-personal/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]
-default = ["native-tokio", "http1", "tls12", "logging", "acceptor"]
+default = ["native-tokio", "http1", "tls12", "logging", "acceptor", "std"]
 acceptor = ["hyper/server", "tokio-runtime"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
@@ -40,6 +40,8 @@ tokio-runtime =  ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
 ring = ["rustls/ring"]
+std = ["rustls/std", "webpki/std", "pki-types/std"]
+alloc = ["rustls/alloc", "webpki/alloc", "pki-types/alloc"]
 
 [[example]]
 name = "client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = "1.0"
 tokio-rustls = { version = "0.24.1", default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 futures-util = { version = "0.3", default-features = false }
+pki-types = { package = "rustls-pki-types", version = "0.2.1", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
@@ -37,7 +38,7 @@ native-tokio = ["tokio-runtime", "rustls-native-certs"]
 tokio-runtime =  ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
-ring = ["rustls/ring"]
+ring = ["rustls/ring", "pki-types"]
 
 [[example]]
 name = "client"
@@ -55,3 +56,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
 rustls = { git = 'https://github.com/rustls/rustls' }
+tokio-rustls = { git = 'https://github.com/stevefan1999-personal/tokio-rustls' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,22 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
-rustls = { git = "https://github.com/stevefan1999-personal/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["dangerous_configuration"] }
+rustls = { git = "https://github.com/rustls/rustls", branch = "main", version = "0.22.0-alpha.2", default-features = false }
 tokio = "1.0"
-tokio-rustls = { git = "https://github.com/stevefan1999-personal/tokio-rustls", branch = "part-4-patch", version = "0.24.0", default-features = false }
+tokio-rustls = { git = "https://github.com/stevefan1999-personal/tokio-rustls", branch = "main", version = "0.24.0", default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 futures-util = { version = "0.3", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.102.0-alpha.3", default-features = false }
+webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.3", default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.1", default-features = false }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { git = "https://github.com/stevefan1999-personal/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["tls12"] }
+rustls = { git = "https://github.com/rustls/rustls", branch = "main", version = "0.22.0-alpha.2", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]
-default = ["native-tokio", "http1", "tls12", "logging", "acceptor", "std"]
+default = ["native-tokio", "http1", "tls12", "logging", "acceptor"]
 acceptor = ["hyper/server", "tokio-runtime"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
@@ -40,8 +40,6 @@ tokio-runtime =  ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
 ring = ["rustls/ring"]
-std = ["rustls/std", "webpki/std", "pki-types/std"]
-alloc = ["rustls/alloc", "webpki/alloc", "pki-types/alloc"]
 
 [[example]]
 name = "client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,20 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
-rustls = { git = "https://github.com/rustls/rustls", branch = "main", version = "0.22.0-alpha.2", default-features = false }
+rustls = { version = "0.22.0-alpha.2", default-features = false }
 tokio = "1.0"
-tokio-rustls = { git = "https://github.com/stevefan1999-personal/tokio-rustls", branch = "main", version = "0.24.0", default-features = false }
+tokio-rustls = { version = "0.24.1", default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 futures-util = { version = "0.3", default-features = false }
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.3", default-features = false }
-pki-types = { package = "rustls-pki-types", version = "0.2.1", default-features = false }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { git = "https://github.com/rustls/rustls", branch = "main", version = "0.22.0-alpha.2", default-features = false, features = ["tls12"] }
+rustls = { version = "0.22.0-alpha.2", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]
-default = ["native-tokio", "http1", "tls12", "logging", "acceptor"]
+default = ["native-tokio", "http1", "tls12", "logging", "acceptor", "ring"]
 acceptor = ["hyper/server", "tokio-runtime"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
@@ -54,3 +52,6 @@ required-features = ["tokio-runtime", "acceptor"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+rustls = { git = 'https://github.com/rustls/rustls' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,17 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
-rustls = { version = "0.21.6", default-features = false }
+rustls = { git = "https://github.com/rustls/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["webpki", "dangerous_configuration"] }
 tokio = "1.0"
-tokio-rustls = { version = "0.24.0", default-features = false }
+tokio-rustls = { git = "https://github.com/stevefan1999-personal/tokio-rustls", branch = "part-4-patch", version = "0.24.0", default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 futures-util = { version = "0.3", default-features = false }
+webpki = { package = "rustls-webpki", version = "0.102.0-alpha.2", default-features = false, features = ["alloc", "std"] }
+pki-types = { package = "rustls-pki-types", version = "0.2.0" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { version = "0.21.0", default-features = false, features = ["tls12"] }
+rustls = { git = "https://github.com/rustls/rustls", branch = "jbp-generalise-crypto-usage-pt4", version = "0.22.0-alpha.2", default-features = false, features = ["webpki", "tls12"] }
 rustls-pemfile = "1.0.0"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
@@ -37,6 +39,7 @@ native-tokio = ["tokio-runtime", "rustls-native-certs"]
 tokio-runtime =  ["hyper/runtime"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
+ring = ["rustls/ring"]
 
 [[example]]
 name = "client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ ring = ["rustls/ring"]
 [[example]]
 name = "client"
 path = "examples/client.rs"
-required-features = ["native-tokio", "http1"]
+required-features = ["native-tokio", "http1", "ring"]
 
 [[example]]
 name = "server"
 path = "examples/server.rs"
-required-features = ["tokio-runtime", "acceptor"]
+required-features = ["tokio-runtime", "acceptor", "ring"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
 rustls = { git = 'https://github.com/rustls/rustls' }
-tokio-rustls = { git = 'https://github.com/stevefan1999-personal/tokio-rustls' }
+tokio-rustls = { git = 'https://github.com/rustls/tokio-rustls' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 rustls-native-certs = { version = "0.7.0-alpha.0", optional = true }
-rustls = { version = "0.22.0-alpha.3", default-features = false }
+rustls = { version = "=0.22.0-alpha.3", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.25.0-alpha.1", default-features = false }
 webpki-roots = { version = "0.26.0-alpha.1", optional = true }
@@ -24,7 +24,7 @@ pki-types = { package = "rustls-pki-types", version = "0.2.1" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { version = "0.22.0-alpha.3", default-features = false, features = ["tls12"] }
+rustls = { version = "=0.22.0-alpha.3", default-features = false, features = ["tls12"] }
 rustls-pemfile = "2.0.0-alpha.1"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ documentation = "https://docs.rs/hyper-rustls/"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
-rustls-native-certs = { version = "0.7.0-alpha.0", optional = true }
+rustls-native-certs = { version = "=0.7.0-alpha.1", optional = true }
 rustls = { version = "=0.22.0-alpha.3", default-features = false }
 tokio = "1.0"
-tokio-rustls = { version = "0.25.0-alpha.1", default-features = false }
-webpki-roots = { version = "0.26.0-alpha.1", optional = true }
+tokio-rustls = { version = "=0.25.0-alpha.1", default-features = false }
+webpki-roots = { version = "=0.26.0-alpha.1", optional = true }
 futures-util = { version = "0.3", default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.1" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
 rustls = { version = "=0.22.0-alpha.3", default-features = false, features = ["tls12"] }
-rustls-pemfile = "2.0.0-alpha.1"
+rustls-pemfile = "=2.0.0-alpha.1"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 [patch.crates-io]
 rustls-native-certs = { git = 'https://github.com/rustls/rustls-native-certs' }
 tokio-rustls = { git = 'https://github.com/rustls/tokio-rustls' }
+rustls-pemfile = { git = 'https://github.com/rustls/pemfile' }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -51,13 +51,13 @@ async fn run_client() -> io::Result<()> {
             let mut roots = RootCertStore::empty();
             roots.add_parsable_certificates(certs);
             // TLS client config using the custom CA store for lookups
-            rustls::ClientConfig::builder_with_ring()
+            rustls::ClientConfig::builder()
                 .with_safe_defaults()
                 .with_root_certificates(roots)
                 .with_no_client_auth()
         }
         // Default TLS client config with native roots
-        None => rustls::ClientConfig::builder_with_ring()
+        None => rustls::ClientConfig::builder()
             .with_safe_defaults()
             .with_native_roots()?
             .with_no_client_auth(),

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,10 +47,7 @@ async fn run_client() -> io::Result<()> {
     let tls = match ca {
         Some(ref mut rd) => {
             // Read trust roots
-            let certs = rustls_pemfile::certs(rd)
-                .map_err(|_| error("failed to load custom CA store".into()))?
-                .into_iter()
-                .map(Into::into);
+            let certs = rustls_pemfile::certs(rd).flat_map(|x| x);
             let mut roots = RootCertStore::empty();
             roots.add_parsable_certificates(certs);
             // TLS client config using the custom CA store for lookups

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,7 +47,7 @@ async fn run_client() -> io::Result<()> {
     let tls = match ca {
         Some(ref mut rd) => {
             // Read trust roots
-            let certs = rustls_pemfile::certs(rd).flat_map(|x| x);
+            let certs = rustls_pemfile::certs(rd).collect::<Result<Vec<_>, _>>()?;
             let mut roots = RootCertStore::empty();
             roots.add_parsable_certificates(certs);
             // TLS client config using the custom CA store for lookups

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -51,13 +51,13 @@ async fn run_client() -> io::Result<()> {
             let mut roots = RootCertStore::empty();
             roots.add_parsable_certificates(certs);
             // TLS client config using the custom CA store for lookups
-            rustls::ClientConfig::builder()
+            rustls::ClientConfig::builder_with_ring()
                 .with_safe_defaults()
                 .with_root_certificates(roots)
                 .with_no_client_auth()
         }
         // Default TLS client config with native roots
-        None => rustls::ClientConfig::builder()
+        None => rustls::ClientConfig::builder_with_ring()
             .with_safe_defaults()
             .with_native_roots()?
             .with_no_client_auth(),

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -48,9 +48,11 @@ async fn run_client() -> io::Result<()> {
         Some(ref mut rd) => {
             // Read trust roots
             let certs = rustls_pemfile::certs(rd)
-                .map_err(|_| error("failed to load custom CA store".into()))?;
+                .map_err(|_| error("failed to load custom CA store".into()))?
+                .into_iter()
+                .map(Into::into);
             let mut roots = RootCertStore::empty();
-            roots.add_parsable_certificates(&certs);
+            roots.add_parsable_certificates(certs);
             // TLS client config using the custom CA store for lookups
             rustls::ClientConfig::builder()
                 .with_safe_defaults()

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -46,7 +46,7 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create a TCP listener via tokio.
     let incoming = AddrIncoming::bind(&addr)?;
     let acceptor = TlsAcceptor::builder()
-        .with_single_cert(certs, key)
+        .with_ring_and_single_cert(certs, key)
         .map_err(|e| error(format!("{}", e)))?
         .with_all_versions_alpn()
         .with_incoming(incoming);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -89,8 +89,7 @@ fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer>> {
     let mut reader = io::BufReader::new(certfile);
 
     // Load and return certificate.
-    let certs = rustls_pemfile::certs(&mut reader)
-        .map_err(|_| error("failed to load certificate".into()))?;
+    let certs = rustls_pemfile::certs(&mut reader).flat_map(|x| x);
     Ok(certs
         .into_iter()
         .map(Into::into)
@@ -105,12 +104,19 @@ fn load_private_key(filename: &str) -> io::Result<PrivateKeyDer> {
     let mut reader = io::BufReader::new(keyfile);
 
     // Load and return a single private key.
-    let keys = rustls_pemfile::rsa_private_keys(&mut reader)
-        .map_err(|_| error("failed to load private key".into()))?;
+    let keys: Vec<pki_types::PrivatePkcs1KeyDer<'static>> =
+        rustls_pemfile::rsa_private_keys(&mut reader)
+            .flat_map(|x| x)
+            .collect();
     if keys.len() != 1 {
         return Err(error("expected a single private key".into()));
     }
 
     // TODO: should PKCS#8 be supported?
-    Ok(PrivateKeyDer::Pkcs1(keys[0].clone().into()))
+    Ok(PrivateKeyDer::Pkcs1(
+        keys[0]
+            .secret_pkcs1_der()
+            .to_owned()
+            .into(),
+    ))
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -88,11 +88,8 @@ fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer>> {
     let mut reader = io::BufReader::new(certfile);
 
     // Load and return certificate.
-    let certs = rustls_pemfile::certs(&mut reader).flat_map(|x| x);
-    Ok(certs
-        .into_iter()
-        .map(Into::into)
-        .collect())
+    let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
+    Ok(certs)
 }
 
 // Load private key from file.
@@ -104,9 +101,7 @@ fn load_private_key(filename: &str) -> io::Result<PrivateKeyDer> {
 
     // Load and return a single private key.
     let keys: Vec<pki_types::PrivatePkcs1KeyDer<'static>> =
-        rustls_pemfile::rsa_private_keys(&mut reader)
-            .flat_map(|x| x)
-            .collect();
+        rustls_pemfile::rsa_private_keys(&mut reader).collect::<Result<Vec<_>, _>>()?;
     if keys.len() != 1 {
         return Err(error("expected a single private key".into()));
     }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -14,6 +14,8 @@ use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use hyper_rustls::TlsAcceptor;
+use pki_types::CertificateDer;
+use pki_types::PrivateKeyDer;
 
 fn main() {
     // Serve an echo service over HTTPS, with proper error handling.
@@ -80,7 +82,7 @@ async fn echo(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
 }
 
 // Load public certificate from file.
-fn load_certs(filename: &str) -> io::Result<Vec<rustls::Certificate>> {
+fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer>> {
     // Open certificate file.
     let certfile = fs::File::open(filename)
         .map_err(|e| error(format!("failed to open {}: {}", filename, e)))?;
@@ -91,12 +93,12 @@ fn load_certs(filename: &str) -> io::Result<Vec<rustls::Certificate>> {
         .map_err(|_| error("failed to load certificate".into()))?;
     Ok(certs
         .into_iter()
-        .map(rustls::Certificate)
+        .map(Into::into)
         .collect())
 }
 
 // Load private key from file.
-fn load_private_key(filename: &str) -> io::Result<rustls::PrivateKey> {
+fn load_private_key(filename: &str) -> io::Result<PrivateKeyDer> {
     // Open keyfile.
     let keyfile = fs::File::open(filename)
         .map_err(|e| error(format!("failed to open {}: {}", filename, e)))?;
@@ -109,5 +111,6 @@ fn load_private_key(filename: &str) -> io::Result<rustls::PrivateKey> {
         return Err(error("expected a single private key".into()));
     }
 
-    Ok(rustls::PrivateKey(keys[0].clone()))
+    // TODO: should PKCS#8 be supported?
+    Ok(PrivateKeyDer::Pkcs1(keys[0].clone().into()))
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -46,7 +46,7 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create a TCP listener via tokio.
     let incoming = AddrIncoming::bind(&addr)?;
     let acceptor = TlsAcceptor::builder()
-        .with_ring_and_single_cert(certs, key)
+        .with_single_cert(certs, key)
         .map_err(|e| error(format!("{}", e)))?
         .with_all_versions_alpn()
         .with_incoming(incoming);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -14,8 +14,7 @@ use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use hyper_rustls::TlsAcceptor;
-use pki_types::CertificateDer;
-use pki_types::PrivateKeyDer;
+use pki_types::{CertificateDer, PrivateKeyDer};
 
 fn main() {
     // Serve an echo service over HTTPS, with proper error handling.

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -27,13 +27,13 @@ impl AcceptorBuilder<WantsTlsConfig> {
     ///
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
     /// [with_no_client_auth]: rustls::ConfigBuilder::with_no_client_auth
-    pub fn with_ring_and_single_cert(
+    pub fn with_single_cert(
         self,
         cert_chain: Vec<pki_types::CertificateDer<'static>>,
         key_der: pki_types::PrivateKeyDer<'static>,
     ) -> Result<AcceptorBuilder<WantsAlpn>, rustls::Error> {
         Ok(AcceptorBuilder(WantsAlpn(
-            ServerConfig::builder_with_ring()
+            ServerConfig::builder()
                 .with_safe_defaults()
                 .with_no_client_auth()
                 .with_single_cert(cert_chain, key_der)?,

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -4,9 +4,7 @@ use hyper::server::conn::AddrIncoming;
 use rustls::ServerConfig;
 
 #[cfg(feature = "ring")]
-use pki_types::CertificateDer;
-#[cfg(feature = "ring")]
-use pki_types::PrivateKeyDer;
+use pki_types::{CertificateDer, PrivateKeyDer};
 
 use super::TlsAcceptor;
 /// Builder for [`TlsAcceptor`]

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -3,9 +3,6 @@ use std::sync::Arc;
 use hyper::server::conn::AddrIncoming;
 use rustls::ServerConfig;
 
-#[cfg(feature = "ring")]
-use pki_types::{CertificateDer, PrivateKeyDer};
-
 use super::TlsAcceptor;
 /// Builder for [`TlsAcceptor`]
 pub struct AcceptorBuilder<State>(State);
@@ -31,8 +28,8 @@ impl AcceptorBuilder<WantsTlsConfig> {
     #[cfg(feature = "ring")]
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<CertificateDer<'static>>,
-        key_der: PrivateKeyDer<'static>,
+        cert_chain: Vec<pki_types::CertificateDer<'static>>,
+        key_der: pki_types::PrivateKeyDer<'static>,
     ) -> Result<AcceptorBuilder<WantsAlpn>, rustls::Error> {
         Ok(AcceptorBuilder(WantsAlpn(
             ServerConfig::builder()

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use hyper::server::conn::AddrIncoming;
-use rustls::{ServerConfig, crypto::CryptoProvider};
+use rustls::{crypto::CryptoProvider, ServerConfig};
 
 use super::TlsAcceptor;
 /// Builder for [`TlsAcceptor`]
@@ -22,7 +22,7 @@ impl AcceptorBuilder<WantsTlsConfig> {
     }
 
     #[cfg(feature = "ring")]
-    /// Use rustls [defaults][with_safe_defaults] without [client authentication][with_no_client_auth], 
+    /// Use rustls [defaults][with_safe_defaults] without [client authentication][with_no_client_auth],
     /// with ring as the provided crypto suites
     ///
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -3,6 +3,11 @@ use std::sync::Arc;
 use hyper::server::conn::AddrIncoming;
 use rustls::ServerConfig;
 
+#[cfg(feature = "ring")]
+use pki_types::CertificateDer;
+#[cfg(feature = "ring")]
+use pki_types::PrivateKeyDer;
+
 use super::TlsAcceptor;
 /// Builder for [`TlsAcceptor`]
 pub struct AcceptorBuilder<State>(State);
@@ -25,10 +30,11 @@ impl AcceptorBuilder<WantsTlsConfig> {
     ///
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
     /// [with_no_client_auth]: rustls::ConfigBuilder::with_no_client_auth
+    #[cfg(feature = "ring")]
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<rustls::Certificate>,
-        key_der: rustls::PrivateKey,
+        cert_chain: Vec<CertificateDer<'static>>,
+        key_der: PrivateKeyDer<'static>,
     ) -> Result<AcceptorBuilder<WantsAlpn>, rustls::Error> {
         Ok(AcceptorBuilder(WantsAlpn(
             ServerConfig::builder()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
-use rustls::client::WantsClientCert;
 use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
+
+#[cfg(any(feature = "rustls-native-certs", feature = "webpki-roots"))]
+use rustls::client::WantsClientCert;
 
 /// Methods for configuring roots
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,19 +8,19 @@ use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 pub trait ConfigBuilderExt {
     /// This configures the platform's trusted certs, as implemented by
     /// rustls-native-certs
-    #[cfg(all(feature = "rustls-native-certs", feature = "ring"))]
+    #[cfg(feature = "rustls-native-certs")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
     fn with_native_roots(self) -> std::io::Result<ConfigBuilder<ClientConfig, WantsClientCert>>;
 
     /// This configures the webpki roots, which are Mozilla's set of
     /// trusted roots as packaged by webpki-roots.
-    #[cfg(all(feature = "webpki-roots", feature = "ring"))]
+    #[cfg(feature = "webpki-roots")]
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
     fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert>;
 }
 
 impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
-    #[cfg(all(feature = "rustls-native-certs", feature = "ring"))]
+    #[cfg(feature = "rustls-native-certs")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
     #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
     fn with_native_roots(self) -> std::io::Result<ConfigBuilder<ClientConfig, WantsClientCert>> {
@@ -55,7 +55,7 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
         Ok(self.with_root_certificates(roots))
     }
 
-    #[cfg(all(feature = "webpki-roots", feature = "ring"))]
+    #[cfg(feature = "webpki-roots")]
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
     fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert> {
         let mut roots = rustls::RootCertStore::empty();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use rustls::client::WantsTransparencyPolicyOrClientCert;
+use pki_types::CertificateDer;
+use rustls::client::WantsClientCert;
 use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 
 /// Methods for configuring roots
@@ -8,33 +9,33 @@ use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 pub trait ConfigBuilderExt {
     /// This configures the platform's trusted certs, as implemented by
     /// rustls-native-certs
-    #[cfg(feature = "rustls-native-certs")]
+    #[cfg(all(feature = "rustls-native-certs", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
-    fn with_native_roots(self) -> ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert>;
+    fn with_native_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert>;
 
     /// This configures the webpki roots, which are Mozilla's set of
     /// trusted roots as packaged by webpki-roots.
-    #[cfg(feature = "webpki-roots")]
+    #[cfg(all(feature = "webpki-roots", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
-    fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert>;
+    fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert>;
 }
 
 impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
-    #[cfg(feature = "rustls-native-certs")]
+    #[cfg(all(feature = "rustls-native-certs", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
     #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
-    fn with_native_roots(self) -> ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert> {
+    fn with_native_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert> {
         let mut roots = rustls::RootCertStore::empty();
         let mut valid_count = 0;
         let mut invalid_count = 0;
 
         for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
         {
-            let cert = rustls::Certificate(cert.0);
-            match roots.add(&cert) {
+            let cert = CertificateDer::from(cert.0);
+            match roots.add(cert.clone()) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
-                    crate::log::trace!("invalid cert der {:?}", cert.0);
+                    crate::log::trace!("invalid cert der {:?}", cert);
                     crate::log::debug!("certificate parsing failed: {:?}", err);
                     invalid_count += 1
                 }
@@ -50,9 +51,9 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
         self.with_root_certificates(roots)
     }
 
-    #[cfg(feature = "webpki-roots")]
+    #[cfg(all(feature = "webpki-roots", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
-    fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert> {
+    fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert> {
         let mut roots = rustls::RootCertStore::empty();
         roots.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,10 +30,10 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
 
         for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
         {
-            match roots.add(cert.0.clone().into()) {
+            match roots.add(cert.as_ref().into()) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
-                    crate::log::trace!("invalid cert der {:?}", cert.0);
+                    crate::log::trace!("invalid cert der {:?}", cert.as_ref());
                     crate::log::debug!("certificate parsing failed: {:?}", err);
                     invalid_count += 1
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,11 +30,10 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
 
         for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
         {
-            let cert = CertificateDer::from(cert.0);
-            match roots.add(cert.clone()) {
+            match roots.add(cert.0.clone().into()) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
-                    crate::log::trace!("invalid cert der {:?}", cert);
+                    crate::log::trace!("invalid cert der {:?}", cert.0);
                     crate::log::debug!("certificate parsing failed: {:?}", err);
                     invalid_count += 1
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use pki_types::CertificateDer;
 use rustls::client::WantsClientCert;
 use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 
@@ -55,16 +54,10 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
     fn with_webpki_roots(self) -> ConfigBuilder<ClientConfig, WantsClientCert> {
         let mut roots = rustls::RootCertStore::empty();
-        roots.add_trust_anchors(
+        roots.extend(
             webpki_roots::TLS_SERVER_ROOTS
                 .iter()
-                .map(|ta| {
-                    rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                        ta.subject,
-                        ta.spki,
-                        ta.name_constraints,
-                    )
-                }),
+                .cloned(),
         );
         self.with_root_certificates(roots)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 pub trait ConfigBuilderExt {
     /// This configures the platform's trusted certs, as implemented by
     /// rustls-native-certs
+    ///
+    /// This will return an error if no valid certs were found. In that case,
+    /// it's recommended to use `with_webpki_roots`.
     #[cfg(feature = "rustls-native-certs")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
     fn with_native_roots(self) -> std::io::Result<ConfigBuilder<ClientConfig, WantsClientCert>>;

--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -1,7 +1,10 @@
 use rustls::ClientConfig;
 
 use super::HttpsConnector;
-#[cfg(any(feature = "rustls-native-certs", feature = "webpki-roots"))]
+#[cfg(all(
+    any(feature = "rustls-native-certs", feature = "webpki-roots"),
+    feature = "ring"
+))]
 use crate::config::ConfigBuilderExt;
 
 #[cfg(feature = "tokio-runtime")]
@@ -57,7 +60,7 @@ impl ConnectorBuilder<WantsTlsConfig> {
     /// See [`ConfigBuilderExt::with_native_roots`]
     ///
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
-    #[cfg(feature = "rustls-native-certs")]
+    #[cfg(all(feature = "rustls-native-certs", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
     pub fn with_native_roots(self) -> ConnectorBuilder<WantsSchemes> {
         self.with_tls_config(

--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -6,6 +6,8 @@ use crate::config::ConfigBuilderExt;
 
 #[cfg(feature = "tokio-runtime")]
 use hyper::client::HttpConnector;
+
+#[cfg(any(feature = "rustls-native-certs", feature = "webpki-roots"))]
 use rustls::crypto::CryptoProvider;
 
 /// A builder for an [`HttpsConnector`]

--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -64,7 +64,7 @@ impl ConnectorBuilder<WantsTlsConfig> {
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
     pub fn with_native_roots(self) -> std::io::Result<ConnectorBuilder<WantsSchemes>> {
         Ok(self.with_tls_config(
-            ClientConfig::builder()
+            ClientConfig::builder_with_ring()
                 .with_safe_defaults()
                 .with_native_roots()?
                 .with_no_client_auth(),
@@ -81,7 +81,7 @@ impl ConnectorBuilder<WantsTlsConfig> {
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
     pub fn with_webpki_roots(self) -> ConnectorBuilder<WantsSchemes> {
         self.with_tls_config(
-            ClientConfig::builder()
+            ClientConfig::builder_with_ring()
                 .with_safe_defaults()
                 .with_webpki_roots()
                 .with_no_client_auth(),
@@ -295,11 +295,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "http1")]
+    #[cfg(all(feature = "http1", feature = "ring"))]
     #[should_panic(expected = "ALPN protocols should not be pre-defined")]
     fn test_reject_predefined_alpn() {
         let roots = rustls::RootCertStore::empty();
-        let mut config_with_alpn = rustls::ClientConfig::builder()
+        let mut config_with_alpn = rustls::ClientConfig::builder_with_ring()
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();
@@ -315,7 +315,7 @@ mod tests {
     #[cfg(all(feature = "http1", feature = "http2"))]
     fn test_alpn() {
         let roots = rustls::RootCertStore::empty();
-        let tls_config = rustls::ClientConfig::builder()
+        let tls_config = rustls::ClientConfig::builder_with_ring()
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();
@@ -359,7 +359,7 @@ mod tests {
     #[cfg(all(not(feature = "http1"), feature = "http2"))]
     fn test_alpn_http2() {
         let roots = rustls::RootCertStore::empty();
-        let tls_config = rustls::ClientConfig::builder()
+        let tls_config = rustls::ClientConfig::builder_with_ring()
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();

--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -60,9 +60,9 @@ impl ConnectorBuilder<WantsTlsConfig> {
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
     #[cfg(all(feature = "rustls-native-certs", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
-    pub fn with_ring_and_native_roots(self) -> std::io::Result<ConnectorBuilder<WantsSchemes>> {
+    pub fn with_native_roots(self) -> std::io::Result<ConnectorBuilder<WantsSchemes>> {
         Ok(self.with_tls_config(
-            ClientConfig::builder_with_ring()
+            ClientConfig::builder()
                 .with_safe_defaults()
                 .with_native_roots()?
                 .with_no_client_auth(),
@@ -77,9 +77,9 @@ impl ConnectorBuilder<WantsTlsConfig> {
     /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
     #[cfg(all(feature = "webpki-roots", feature = "ring"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
-    pub fn with_ring_and_webpki_roots(self) -> ConnectorBuilder<WantsSchemes> {
+    pub fn with_webpki_roots(self) -> ConnectorBuilder<WantsSchemes> {
         self.with_tls_config(
-            ClientConfig::builder_with_ring()
+            ClientConfig::builder()
                 .with_safe_defaults()
                 .with_webpki_roots()
                 .with_no_client_auth(),
@@ -337,7 +337,7 @@ mod tests {
     #[should_panic(expected = "ALPN protocols should not be pre-defined")]
     fn test_reject_predefined_alpn() {
         let roots = rustls::RootCertStore::empty();
-        let mut config_with_alpn = rustls::ClientConfig::builder_with_ring()
+        let mut config_with_alpn = rustls::ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();
@@ -350,10 +350,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "http1", feature = "http2"))]
+    #[cfg(all(feature = "http1", feature = "http2", feature = "ring"))]
     fn test_alpn() {
         let roots = rustls::RootCertStore::empty();
-        let tls_config = rustls::ClientConfig::builder_with_ring()
+        let tls_config = rustls::ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();
@@ -394,10 +394,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(not(feature = "http1"), feature = "http2"))]
+    #[cfg(all(not(feature = "http1"), feature = "http2", feature = "ring"))]
     fn test_alpn_http2() {
         let roots = rustls::RootCertStore::empty();
-        let tls_config = rustls::ClientConfig::builder_with_ring()
+        let tls_config = rustls::ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,16 +47,16 @@
 //! let mut reader = io::BufReader::new(certfile);
 //!
 //! // Load and return certificate.
-//! let certs = rustls_pemfile::certs(&mut reader).unwrap();
-//! let certs = certs.into_iter().map(Into::into).collect();
+//! let certs = rustls_pemfile::certs(&mut reader).flat_map(|x| x);
+//! let certs = certs.map(Into::into).collect();
 //!
 //! // Load private key. (see `examples/server.rs`)
 //! let keyfile = File::open("examples/sample.rsa").unwrap();
 //! let mut reader = io::BufReader::new(keyfile);
 //!
 //! // Load and return a single private key.
-//! let keys = rustls_pemfile::rsa_private_keys(&mut reader).unwrap();
-//! let key = pki_types::PrivateKeyDer::Pkcs1(keys[0].clone().into());
+//! let keys: Vec<pki_types::PrivatePkcs1KeyDer<'static>> = rustls_pemfile::rsa_private_keys(&mut reader).flat_map(|x| x).collect();
+//! let key = pki_types::PrivateKeyDer::Pkcs1(keys[0].secret_pkcs1_der().to_vec().into());
 //! let https = hyper_rustls::HttpsConnectorBuilder::new()
 //!     .with_native_roots()
 //!     .https_only()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@
 #[cfg(feature = "acceptor")]
 /// TLS acceptor implementing hyper's `Accept` trait.
 pub mod acceptor;
-#[cfg(feature = "ring")]
 mod config;
 mod connector;
 mod stream;
@@ -101,7 +100,6 @@ mod log {
 
 #[cfg(feature = "acceptor")]
 pub use crate::acceptor::{AcceptorBuilder, TlsAcceptor};
-#[cfg(feature = "ring")]
 pub use crate::config::ConfigBuilderExt;
 pub use crate::connector::builder::ConnectorBuilder as HttpsConnectorBuilder;
 pub use crate::connector::HttpsConnector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@
 //! let mut reader = io::BufReader::new(keyfile);
 //!
 //! // Load and return a single private key.
-//! let keys: Vec<pki_types::PrivatePkcs1KeyDer<'static>> = rustls_pemfile::rsa_private_keys(&mut reader).collect::<Result<Vec<_>, _>>().unwrap();
-//! let key = pki_types::PrivateKeyDer::Pkcs1(keys[0].secret_pkcs1_der().to_vec().into());
+//! let key = rustls_pemfile::private_key(&mut reader).unwrap().unwrap();
 //! let https = hyper_rustls::HttpsConnectorBuilder::new()
 //!     .with_native_roots()
 //!     .expect("no native root CA certificates found")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 #[cfg(feature = "acceptor")]
 /// TLS acceptor implementing hyper's `Accept` trait.
 pub mod acceptor;
+#[cfg(feature = "ring")]
 mod config;
 mod connector;
 mod stream;
@@ -100,6 +101,7 @@ mod log {
 
 #[cfg(feature = "acceptor")]
 pub use crate::acceptor::{AcceptorBuilder, TlsAcceptor};
+#[cfg(feature = "ring")]
 pub use crate::config::ConfigBuilderExt;
 pub use crate::connector::builder::ConnectorBuilder as HttpsConnectorBuilder;
 pub use crate::connector::HttpsConnector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! // Load and return certificate.
 //! let certs = rustls_pemfile::certs(&mut reader).unwrap();
-//! let certs = certs.into_iter().map(rustls::Certificate).collect();
+//! let certs = certs.into_iter().map(Into::into).collect();
 //!
 //! // Load private key. (see `examples/server.rs`)
 //! let keyfile = File::open("examples/sample.rsa").unwrap();
@@ -56,7 +56,7 @@
 //!
 //! // Load and return a single private key.
 //! let keys = rustls_pemfile::rsa_private_keys(&mut reader).unwrap();
-//! let key = rustls::PrivateKey(keys[0].clone());
+//! let key = pki_types::PrivateKeyDer::Pkcs1(keys[0].clone().into());
 //! let https = hyper_rustls::HttpsConnectorBuilder::new()
 //!     .with_native_roots()
 //!     .https_only()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Example client
 //!
 //! ```no_run
-//! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1"))]
+//! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1", feature = "ring"))]
 //! # fn main() {
 //! use hyper::{Body, Client, StatusCode, Uri};
 //!
@@ -24,14 +24,14 @@
 //! let res = rt.block_on(client.get(url)).unwrap();
 //! assert_eq!(res.status(), StatusCode::OK);
 //! # }
-//! # #[cfg(not(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1")))]
+//! # #[cfg(not(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1", feature = "ring")))]
 //! # fn main() {}
 //! ```
 //!
 //! ## Example server
 //!
 //! ```no_run
-//! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1", feature = "acceptor"))]
+//! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1", feature = "acceptor", feature = "ring"))]
 //! # fn main() {
 //! use hyper::server::conn::AddrIncoming;
 //! use hyper::service::{make_service_fn, service_fn};
@@ -72,7 +72,7 @@
 //! let server = Server::builder(acceptor).serve(service);
 //! // server.await.unwrap();
 //! # }
-//! # #[cfg(not(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1")))]
+//! # #[cfg(not(all(feature = "rustls-native-certs", feature = "tokio-runtime", feature = "http1", feature = "ring")))]
 //! # fn main() {}
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,15 +47,14 @@
 //! let mut reader = io::BufReader::new(certfile);
 //!
 //! // Load and return certificate.
-//! let certs = rustls_pemfile::certs(&mut reader).flat_map(|x| x);
-//! let certs = certs.map(Into::into).collect();
+//! let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>().unwrap();
 //!
 //! // Load private key. (see `examples/server.rs`)
 //! let keyfile = File::open("examples/sample.rsa").unwrap();
 //! let mut reader = io::BufReader::new(keyfile);
 //!
 //! // Load and return a single private key.
-//! let keys: Vec<pki_types::PrivatePkcs1KeyDer<'static>> = rustls_pemfile::rsa_private_keys(&mut reader).flat_map(|x| x).collect();
+//! let keys: Vec<pki_types::PrivatePkcs1KeyDer<'static>> = rustls_pemfile::rsa_private_keys(&mut reader).collect::<Result<Vec<_>, _>>().unwrap();
 //! let key = pki_types::PrivateKeyDer::Pkcs1(keys[0].secret_pkcs1_der().to_vec().into());
 //! let https = hyper_rustls::HttpsConnectorBuilder::new()
 //!     .with_native_roots()


### PR DESCRIPTION
This is blocked partially https://github.com/rustls/tokio-rustls/pull/21 and awaiting for a while until the new rustls alpha version is released because there are some key changes (making ring optional, dynamic crypto provider). My own patch fork tracks all the latest changes.