### PR TITLE
Prepare 0.24.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Someone asked for this privately in order to help avoid duplicate dependencies (in particular, webpki-roots).

## Proposed release notes

* Tweak behavior of `enable_all_versions()` based on enabled versions
* Add `AcceptorBuilder::with_acceptor()` builder method