### PR TITLE
ci: check semver compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,18 @@ jobs:
       - name: Check MSRV
         run: cargo check --lib --all-features
 
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   docs:
     name: Check for documentation errors
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Use `cargo-semver-checks-action` in CI to try and catch semver breaking changes being made without the correct `Cargo.toml` version update.

Note: not perfect - this check passing is necessary but not sufficient for maintaining semver.