### PR TITLE
Update to rustls 0.22.0 alpha.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,3 +145,17 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --all-features -- --deny warnings
+
+  features:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: Check feature powerset
+        run: cargo hack --no-dev-deps check --feature-powerset --depth 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
 pki-types = { package = "rustls-pki-types", version = "0.2" }
-rustls-native-certs = { version = "=0.7.0-alpha.2", optional = true }
-rustls = { version = "=0.22.0-alpha.5", default-features = false }
+rustls-native-certs = { version = "=0.7.0-alpha.3", optional = true }
+rustls = { version = "=0.22.0-alpha.6", default-features = false }
 tokio = "1.0"
-tokio-rustls = { version = "=0.25.0-alpha.3", default-features = false }
+tokio-rustls = { version = "=0.25.0-alpha.4", default-features = false }
 webpki-roots = { version = "=0.26.0-alpha.2", optional = true }
 futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { version = "=0.22.0-alpha.5", default-features = false, features = ["tls12"] }
+rustls = { version = "=0.22.0-alpha.6", default-features = false, features = ["tls12"] }
 rustls-pemfile = "=2.0.0-alpha.2"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thre
 
 [features]
 default = ["native-tokio", "http1", "tls12", "logging", "acceptor", "ring"]
-acceptor = ["hyper/server", "tokio-runtime"]
+acceptor = ["hyper/server", "ring", "tokio-runtime"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 webpki-tokio = ["tokio-runtime", "webpki-roots"]


### PR DESCRIPTION
Updates to `rustls` 0.22.0-alpha.6, fixes a feature requirement, and adds a ci job to check each feature.