### PR TITLE
hyper-rustls 0.25 prep, rustls 0.22 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target/
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.25.0-alpha.0"
+version = "0.25.0"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ documentation = "https://docs.rs/hyper-rustls/"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 log = { version = "0.4.4", optional = true }
-pki-types = { package = "rustls-pki-types", version = "0.2" }
-rustls-native-certs = { version = "=0.7.0-alpha.3", optional = true }
-rustls = { version = "=0.22.0-alpha.6", default-features = false }
+pki-types = { package = "rustls-pki-types", version = "1" }
+rustls-native-certs = { version = "0.7", optional = true }
+rustls = { version = "0.22", default-features = false }
 tokio = "1.0"
-tokio-rustls = { version = "=0.25.0-alpha.4", default-features = false }
-webpki-roots = { version = "=0.26.0-alpha.2", optional = true }
+tokio-rustls = { version = "0.25", default-features = false }
+webpki-roots = { version = "0.26", optional = true }
 futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }
-rustls = { version = "=0.22.0-alpha.6", default-features = false, features = ["tls12"] }
-rustls-pemfile = "=2.0.0-alpha.2"
+rustls = { version = "0.22", default-features = false, features = ["tls12"] }
+rustls-pemfile = "2"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 
 [features]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -52,13 +52,11 @@ async fn run_client() -> io::Result<()> {
             roots.add_parsable_certificates(certs);
             // TLS client config using the custom CA store for lookups
             rustls::ClientConfig::builder()
-                .with_safe_defaults()
                 .with_root_certificates(roots)
                 .with_no_client_auth()
         }
         // Default TLS client config with native roots
         None => rustls::ClientConfig::builder()
-            .with_safe_defaults()
             .with_native_roots()?
             .with_no_client_auth(),
     };

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -22,9 +22,9 @@ impl AcceptorBuilder<WantsTlsConfig> {
         AcceptorBuilder(WantsAlpn(config))
     }
 
-    /// Use rustls [defaults][with_safe_defaults] without [client authentication][with_no_client_auth]
+    /// Use rustls default crypto provider and safe defaults without
+    /// [client authentication][with_no_client_auth]
     ///
-    /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
     /// [with_no_client_auth]: rustls::ConfigBuilder::with_no_client_auth
     pub fn with_single_cert(
         self,
@@ -33,7 +33,6 @@ impl AcceptorBuilder<WantsTlsConfig> {
     ) -> Result<AcceptorBuilder<WantsAlpn>, rustls::Error> {
         Ok(AcceptorBuilder(WantsAlpn(
             ServerConfig::builder()
-                .with_safe_defaults()
                 .with_no_client_auth()
                 .with_single_cert(cert_chain, key_der)?,
         )))


### PR DESCRIPTION
## Description

This branch updates to rustls 0.22 and bumps the crate version from 0.25.0-alpha.0 to 0.25, taking the following associated updates:

* rustls 0.22.0-alpha-6 -> 0.22
* pki-types 0.2 -> 1
* tokio-rustls 0.25.0-alpha.4 -> 0.25
* rustls-native-certs 0.7.0-alpha.3 -> 0.7
* webpki-roots 0.26.0-alpha.2 -> 0.26
* rustls-pemfile 2.0.0-alpha.2 -> 2

Breaking API changes are addressed as required. Notably, the `with_provider_and_webpki_roots` builder fn that accepts a custom provider and uses the safe default protocol versions is now fallible to account for a possible error if the provider's configuration is not compatible.
