### PR TITLE
Style tweaks

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -5,10 +5,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures_util::ready;
-use hyper::server::{
-    accept::Accept,
-    conn::{AddrIncoming, AddrStream},
-};
+use hyper::server::accept::Accept;
+use hyper::server::conn::{AddrIncoming, AddrStream};
 use rustls::{ServerConfig, ServerConnection};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 

--- a/src/acceptor/builder.rs
+++ b/src/acceptor/builder.rs
@@ -5,6 +5,7 @@ use pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::ServerConfig;
 
 use super::TlsAcceptor;
+
 /// Builder for [`TlsAcceptor`]
 pub struct AcceptorBuilder<State>(State);
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -70,16 +70,8 @@ where
         };
 
         if scheme == &http::uri::Scheme::HTTP && !self.force_https {
-            let connecting_future = self.http.call(dst);
-
-            let f = async move {
-                let tcp = connecting_future
-                    .await
-                    .map_err(Into::into)?;
-
-                Ok(MaybeHttpsStream::Http(tcp))
-            };
-            Box::pin(f)
+            let future = self.http.call(dst);
+            Box::pin(async move { Ok(MaybeHttpsStream::Http(future.await.map_err(Into::into)?)) })
         } else if scheme == &http::uri::Scheme::HTTPS {
             let cfg = self.tls_config.clone();
             let mut hostname = match self.override_server_name.as_deref() {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -33,28 +33,6 @@ impl<T> HttpsConnector<T> {
     }
 }
 
-impl<T> fmt::Debug for HttpsConnector<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("HttpsConnector")
-            .field("force_https", &self.force_https)
-            .finish()
-    }
-}
-
-impl<H, C> From<(H, C)> for HttpsConnector<H>
-where
-    C: Into<Arc<rustls::ClientConfig>>,
-{
-    fn from((http, cfg): (H, C)) -> Self {
-        Self {
-            force_https: false,
-            http,
-            tls_config: cfg.into(),
-            override_server_name: None,
-        }
-    }
-}
-
 impl<T> Service<Uri> for HttpsConnector<T>
 where
     T: Service<Uri>,
@@ -137,5 +115,27 @@ where
             let err = io::Error::new(io::ErrorKind::Other, "Missing scheme");
             Box::pin(async move { Err(err.into()) })
         }
+    }
+}
+
+impl<H, C> From<(H, C)> for HttpsConnector<H>
+where
+    C: Into<Arc<rustls::ClientConfig>>,
+{
+    fn from((http, cfg): (H, C)) -> Self {
+        Self {
+            force_https: false,
+            http,
+            tls_config: cfg.into(),
+            override_server_name: None,
+        }
+    }
+}
+
+impl<T> fmt::Debug for HttpsConnector<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("HttpsConnector")
+            .field("force_https", &self.force_https)
+            .finish()
     }
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{fmt, io};
 
-use hyper::{client::connect::Connection, service::Service, Uri};
+use hyper::client::connect::Connection;
+use hyper::service::Service;
+use hyper::Uri;
 use pki_types::ServerName;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::TlsConnector;


### PR DESCRIPTION
Clean up code style in hyper-rustls before refactoring to support hyper 1, bringing things in line with rustls [code style](https://github.com/rustls/rustls/blob/main/CONTRIBUTING.md).