### PR TITLE
feat: wrap_connector from builder WantsProtocols1

### DIFF
--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -228,6 +228,15 @@ impl ConnectorBuilder<WantsProtocols1> {
         })
     }
 
+    /// This wraps an arbitrary low-level connector into an [`HttpsConnector`]
+    pub fn wrap_connector<H>(self, conn: H) -> HttpsConnector<H> {
+        // HTTP1-only, alpn_protocols stays empty
+        // HttpConnector doesn't have a way to say http1-only;
+        // its connection pool may still support HTTP2
+        // though it won't be used
+        self.0.wrap_connector(conn)
+    }
+
     /// Override server name for the TLS stack
     ///
     /// By default, for each connection hyper-rustls will extract host portion


### PR DESCRIPTION
There is a use case for wrapping libraries where they may not bring in either `http` or `http2` features, but still want to set advanced configuration but with their own lower-level connector.

This was discovered when trying to expose `builder::with_server_name()` in `reqwest`, which seems impossible right now without enabling extra features.