### PR TITLE
Add feature flag for enabling FIPS.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - id: collect-non-fips-features
         run: |
           yq --no-colors -oy '.features | keys | . - ["default", "fips"] | join(",") | "non-fips-features=" + @sh'  Cargo.toml >> "$GITHUB_OUTPUT"
-          yq --no-colors -oy '.features["default"] + ["ring"] | join(",") | "defaults-with-ring-features=" + @sh' Cargo.toml >> "$GITHUB_OUTPUT"
+          yq --no-colors -oy '.features["default"] - ["aws-lc-rs"] + ["ring"] | join(",") | "defaults-with-ring-features=" + @sh' Cargo.toml >> "$GITHUB_OUTPUT"
   build:
     name: Build+test
     needs: collect-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,10 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; defaults+ring)
-        env:
-          DEFAULTS_WITH_RING_FEATURES: ${{ needs.collect-features.outputs.DEFAULTS_WITH_RING_FEATURES }}
         run: cargo test --no-default-features --features $DEFAULTS_WITH_RING_FEATURES
         env:
           RUST_BACKTRACE: 1
+          DEFAULTS_WITH_RING_FEATURES: ${{ needs.collect-features.outputs.DEFAULTS_WITH_RING_FEATURES }}
 
       - name: cargo test (debug; all features)
         if: runner.os == 'Linux'
@@ -93,11 +92,10 @@ jobs:
 
       - name: cargo test (debug; all features, excluding FIPS)
         if: runner.os != 'Linux'
-        env:
-          NON_FIPS_FEATURES: ${{ needs.collect-features.outputs.NON_FIPS_FEATURES }}
         run: cargo test --features $NON_FIPS_FEATURES
         env:
           RUST_BACKTRACE: 1
+          NON_FIPS_FEATURES: ${{ needs.collect-features.outputs.NON_FIPS_FEATURES }}
 
       - name: cargo build (debug; no default features)
         run: cargo build --no-default-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,20 @@ on:
     - cron: '23 6 * * 5'
 
 jobs:
+  collect-features:
+    name: Collect package features
+    runs-on: ubuntu-latest
+    outputs:
+      NON_FIPS_FEATURES: ${{ steps.collect-non-fips-features.outputs.non-fips-features }}
+      DEFAULTS_WITH_RING_FEATURES: ${{ steps.collect-non-fips-features.outputs.defaults-with-ring-features }}
+    steps:
+      - id: collect-non-fips-features
+        run: |
+          yq --no-colors -oy '.features | keys | . - ["default", "fips"] | join(",") | "non-fips-features=" + @sh'  Cargo.toml >> "$GITHUB_OUTPUT"
+          yq --no-colors -oy '.features["default"] + ["ring"] | join(",") | "defaults-with-ring-features=" + @sh' Cargo.toml >> "$GITHUB_OUTPUT"
   build:
     name: Build+test
+    needs: collect-features
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -67,12 +79,23 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; defaults+ring)
-        run: cargo test --no-default-features --features ring,native-tokio,http1,tls12,logging
+        env:
+          DEFAULTS_WITH_RING_FEATURES: ${{ needs.collect-features.outputs.DEFAULTS_WITH_RING_FEATURES }}
+        run: cargo test --no-default-features --features $DEFAULTS_WITH_RING_FEATURES
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; all features)
+        if: runner.os == 'Linux'
         run: cargo test --all-features
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: cargo test (debug; all features, excluding FIPS)
+        if: runner.os != 'Linux'
+        env:
+          NON_FIPS_FEATURES: ${{ needs.collect-features.outputs.NON_FIPS_FEATURES }}
+        run: cargo test --features $NON_FIPS_FEATURES
         env:
           RUST_BACKTRACE: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,6 @@ on:
     - cron: '23 6 * * 5'
 
 jobs:
-  collect-features:
-    name: Collect package features
-    runs-on: ubuntu-latest
-    outputs:
-      NON_FIPS_FEATURES: ${{ steps.collect-non-fips-features.outputs.non-fips-features }}
-      DEFAULTS_WITH_RING_FEATURES: ${{ steps.collect-non-fips-features.outputs.defaults-with-ring-features }}
-    steps:
-      - id: collect-non-fips-features
-        run: |
-          yq --no-colors -oy '.features | keys | . - ["default", "fips"] | join(",") | "non-fips-features=" + @sh'  Cargo.toml >> "$GITHUB_OUTPUT"
-          yq --no-colors -oy '.features["default"] - ["aws-lc-rs"] + ["ring"] | join(",") | "defaults-with-ring-features=" + @sh' Cargo.toml >> "$GITHUB_OUTPUT"
   build:
     name: Build+test
     needs: collect-features
@@ -79,10 +68,9 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; defaults+ring)
-        run: cargo test --no-default-features --features $DEFAULTS_WITH_RING_FEATURES
+        run: cargo test --no-default-features --features ring,native-tokio,http1,tls12,logging
         env:
           RUST_BACKTRACE: 1
-          DEFAULTS_WITH_RING_FEATURES: ${{ needs.collect-features.outputs.DEFAULTS_WITH_RING_FEATURES }}
 
       - name: cargo test (debug; all features)
         if: runner.os == 'Linux'
@@ -92,10 +80,9 @@ jobs:
 
       - name: cargo test (debug; all features, excluding FIPS)
         if: runner.os != 'Linux'
-        run: cargo test --features $NON_FIPS_FEATURES
+        run: cargo test --features aws-lc-rs,http1,http2,webpki-tokio,native-tokio,ring,tls12,logging
         env:
           RUST_BACKTRACE: 1
-          NON_FIPS_FEATURES: ${{ needs.collect-features.outputs.NON_FIPS_FEATURES }}
 
       - name: cargo build (debug; no default features)
         run: cargo build --no-default-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   build:
     name: Build+test
-    needs: collect-features
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ native-tokio = ["rustls-native-certs"]
 ring = ["rustls/ring"]
 tls12 = ["tokio-rustls/tls12", "rustls/tls12"]
 logging = ["log", "tokio-rustls/logging", "rustls/logging"]
+fips = ["aws-lc-rs", "rustls/fips"]
 
 [[example]]
 name = "client"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,28 @@ cargo run --example server
 ```bash
 cargo run --example client "https://docs.rs/hyper-rustls/latest/hyper_rustls/"
 ```
+
+## Crate features
+
+This crate exposes a number of features to add support for different portions of `hyper-util`,
+`rustls`, and other dependencies.
+
+| Feature flag | Enabled by default | Description |
+| ------------ | ------------------ | ----------- |
+| `aws-lc-rs`  | **yes** | Enables use of the [AWS-LC][aws-lc-rs] backend for [`rustls`][rustls] |
+| `http1` | **yes** | Enables HTTP/1 support in [`hyper-util`][hyper-util] |
+| `http2` | **no** | Enables HTTP/2 support in [`hyper-util`][hyper-util] |
+| `webpki-tokio` | **no** | Uses a compiled-in set of root certificates trusted by Mozilla (via [`webpki-roots`][webpki-roots]) |
+| `native-tokio` | **yes** | Use the platform's native certificate store at runtime (via [`rustls-native-certs`][rustls-native-certs]) |
+| `ring` | **no** | Enables use of the [`ring`][ring] backend for [`rustls`][rustls] |
+| `tls12` | **yes** | Enables support for TLS 1.2 (only TLS 1.3 supported when disabled) |
+| `logging` | **yes** | Enables logging of protocol-level diagnostics and errors via [`log`][log] |
+| `fips` | **no** | Enables support for using a FIPS 140-3 compliant backend via AWS-LC (enables `aws-lc-rs` feature) |
+
+[aws-lc-rs]: https://docs.rs/aws-lc-rs
+[rustls]: https://docs.rs/rustls
+[hyper-util]: https://docs.rs/hyper-util
+[webpki-roots]: https://docs.rs/webpki-roots
+[rustls-native-certs]: https://docs.rs/rustls-native-certs
+[ring]: https://docs.rs/ring
+[log]: https://docs.rs/log


### PR DESCRIPTION
As described.

Adds a new feature flag, `fips`, to enable FIPS in `rustls`.

Verified that when enabling the new `fips` feature flag, that FIPS mode is used in `aws-lc-rs` (by seeing `aws-lc-fips-sys` being used.).

Resolves https://github.com/rustls/hyper-rustls/issues/267