### PR TITLE
Cargo: v0.27.0 -> v0.27.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 rust-version = "1.64"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
# Proposed Release Notes

## Added

* New `ConnectorBuilder::with_server_name_resolver()` fn for specifying an implementation of the `ResolveServerName` trait to dynamically resolve the subject name used when verifying a server's certificate.
* New `fips` feature flag for enabling the `aws-lc-rs` Rustls crypto provider in FIPS mode.

## Changed

* `ConnectorBuilder::with_server_name()` is now deprecated. Existing usages should be replaced with `ConnectorBuilder::with_server_name_resolver()` and a `FixedServerNameResolver`.