### PR TITLE
Avoid `aws-lc-rs` feature flag when building docs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,8 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo doc (all features)
-        run: cargo doc --all-features --no-deps
+        # keep features in sync with Cargo.toml `[package.metadata.docs.rs]` section
+        run: cargo doc --no-default-features --features http1,http2,webpki-tokio,native-tokio,ring,tls12,logging --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,6 @@ path = "examples/server.rs"
 required-features = ["aws-lc-rs"]
 
 [package.metadata.docs.rs]
-all-features = true
+no-default-features = true
+features = ["http1","http2","webpki-tokio","native-tokio","ring","tls12","logging"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,5 @@ required-features = ["aws-lc-rs"]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["http1","http2","webpki-tokio","native-tokio","ring","tls12","logging"]
+features = ["http1", "http2", "webpki-tokio", "native-tokio", "ring", "tls12", "logging"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
As stated in the title.

Mimics the fix in rustls/rustls#1827 by simply enabling all features manually, minus `aws-lc-rs`. This avoids trying to build it at in during docs.rs generation, as docs.rs _can't_ currently compile it, whether or not FIPS is enabled.

There's nothing in the API, though, that depends on the feature flag so we didn't have to do anything in the code itself to cope with not passing the `aws-lc-rs` feature flag when building docs.

Tested locally using the docs.rs [build instructions](https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand) and verified that the build was broken prior to this fix, and the build completed successfully with this fix.

Fixes #272.