### PR TITLE
Bump version to 0.27.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.27.1"
+version = "0.27.2"
 edition = "2021"
 rust-version = "1.64"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
To get #273 out, fixing https://github.com/rust-lang/docs.rs/issues/2513.