### PR TITLE
fix: add rustls-platform-verifier flag for importing ConfigBuilderExt

### DIFF
--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -6,7 +6,11 @@ use rustls::crypto::CryptoProvider;
 use rustls::ClientConfig;
 
 use super::{DefaultServerNameResolver, HttpsConnector, ResolveServerName};
-#[cfg(any(feature = "rustls-native-certs", feature = "webpki-roots"))]
+#[cfg(any(
+    feature = "rustls-native-certs",
+    feature = "webpki-roots",
+    feature = "rustls-platform-verifier"
+))]
 use crate::config::ConfigBuilderExt;
 use pki_types::ServerName;
 


### PR DESCRIPTION
Hello! Thank you so much for actively developing!

I found a (maybe) potential bug when I import `hyper-rustls` with `rustls-platform-verifier` feature. If `hyper-rustls` with `rustls-platform-verifier` (+`aws-lc-rs` or `ring`) and `default-features = false`, we cannot build the following code

```rust
let client =  hyper_rustls::HttpsConnectorBuilder::new().with_platform_verifier()
```

with  error message: "no method named `with_platform_verifier` found for struct `ConfigBuilder` in the current scope".

The reason why this build failure occurs is that in `src/connector/builder.rs`, `ConfigBuilderExt` is imported only when either one of `rustls-native-certs` or `webpki-roots` is enabled. Thus, I fixed the code a bit (just added feature flag).

Of course I know that feature `rustls-platform-verifier` is not public on README.md and that `native-tokio`, i.e., `rustls-native-certs`, seems to be prioritized over the feature. But I am very happy if this would be considered! Thank you.

Jun