### PR TITLE
Builder fixes

### DIFF
--- a/src/connector/builder.rs
+++ b/src/connector/builder.rs
@@ -87,7 +87,7 @@ impl ConnectorBuilder<WantsTlsConfig> {
     #[cfg(feature = "rustls-platform-verifier")]
     pub fn with_provider_and_platform_verifier(
         self,
-        provider: CryptoProvider,
+        provider: impl Into<Arc<CryptoProvider>>,
     ) -> std::io::Result<ConnectorBuilder<WantsSchemes>> {
         Ok(self.with_tls_config(
             ClientConfig::builder_with_provider(provider.into())
@@ -120,7 +120,7 @@ impl ConnectorBuilder<WantsTlsConfig> {
     #[cfg(feature = "rustls-native-certs")]
     pub fn with_provider_and_native_roots(
         self,
-        provider: CryptoProvider,
+        provider: impl Into<Arc<CryptoProvider>>,
     ) -> std::io::Result<ConnectorBuilder<WantsSchemes>> {
         Ok(self.with_tls_config(
             ClientConfig::builder_with_provider(provider.into())
@@ -151,7 +151,7 @@ impl ConnectorBuilder<WantsTlsConfig> {
     #[cfg(feature = "webpki-roots")]
     pub fn with_provider_and_webpki_roots(
         self,
-        provider: CryptoProvider,
+        provider: impl Into<Arc<CryptoProvider>>,
     ) -> Result<ConnectorBuilder<WantsSchemes>, rustls::Error> {
         Ok(self.with_tls_config(
             ClientConfig::builder_with_provider(provider.into())


### PR DESCRIPTION
These are two changes to make the most recent hyper-rustls release usable for us in [twilight](https://github.com/twilight-rs/twilight). We also ran into the issue that was fixed by commit https://github.com/rustls/hyper-rustls/commit/c56c76a99ab0e9413fba5cc04df2d4fcbfd45735 in our CI, I would be very grateful for a new release with these commits to allow us to finally upgrade rustls.

The first commit adds a method that I think was overlooked when the rustls-platform-verifier support was initially added.

The second commit resolves #282 in a backwards-compatible manner.