### PR TITLE
Bump MSRV to 1.71 to match other crates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.70"
+          toolchain: "1.71"
 
       - name: Check MSRV
         run: cargo check --lib --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyper-rustls"
 version = "0.27.3"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README.md"
 description = "Rustls+hyper integration for pure rust HTTPS"


### PR DESCRIPTION
The scheduled CI run failed because rustls-native-certs has 1.71 as its MSRV.