### PR TITLE
tests: fix clippy::zombie_processes findings

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -60,6 +60,8 @@ fn server() {
         .expect("cannot run curl");
 
     srv.kill().unwrap();
+    srv.wait()
+        .expect("failed to wait on server process");
 
     if !output.status.success() {
         let version_stdout = Command::new("curl")
@@ -91,6 +93,8 @@ fn custom_ca_store() {
         .expect("cannot run client example");
 
     srv.kill().unwrap();
+    srv.wait()
+        .expect("failed to wait on server process");
 
     if !rc.status.success() {
         assert_eq!(String::from_utf8_lossy(&rc.stdout), "");


### PR DESCRIPTION
of the form:
```
error: spawned process is never `wait()`ed on
  --> tests/tests.rs:47:19
   |
47 |       let mut srv = server_command()
   |  ___________________^
48 | |         .arg("1337")
49 | |         .spawn()
50 | |         .expect("cannot run server example");
   | |____________________________________________^
   |
   = note: consider calling `.wait()`
   = note: not doing so might leave behind zombie processes
   = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#zombie_processes
   = note: `-D clippy::zombie-processes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::zombie_processes)]`
```