### PR TITLE
Actually use configured crypto provider for the platform verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.4"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,9 +43,10 @@ pub trait ConfigBuilderExt {
 impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
     #[cfg(feature = "rustls-platform-verifier")]
     fn with_platform_verifier(self) -> ConfigBuilder<ClientConfig, WantsClientCert> {
+        let provider = self.crypto_provider().clone();
         self.dangerous()
             .with_custom_certificate_verifier(Arc::new(
-                rustls_platform_verifier::Verifier::default(),
+                rustls_platform_verifier::Verifier::new().with_provider(provider),
             ))
     }
 


### PR DESCRIPTION
`rustls-platform-verifier`'s `Verifier` needs to be told about the provider that is being used, otherwise it would error if no process-wide default had been installed. `with_provider_and_platform_verifier` does create the `ClientConfig` with the crypto provider and then calls `with_platform_verifier`, but the platform verifier was previously never made aware of the crypto provider.