### PR TITLE
Prepare 0.27.5 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.27.4"
+version = "0.27.5"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ webpki-roots = { version = "0.26", optional = true }
 futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
+cfg-if = "1"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", default-features = false, features = ["server-auto"] }
 rustls = { version = "0.23", default-features = false, features = ["tls12"] }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -220,6 +220,11 @@ mod tests {
     use crate::{ConfigBuilderExt, HttpsConnectorBuilder};
 
     fn tls_config() -> rustls::ClientConfig {
+        #[cfg(feature = "rustls-platform-verifier")]
+        return rustls::ClientConfig::builder()
+            .with_platform_verifier()
+            .with_no_client_auth();
+
         #[cfg(feature = "rustls-native-certs")]
         return rustls::ClientConfig::builder()
             .with_native_roots()
@@ -229,11 +234,6 @@ mod tests {
         #[cfg(feature = "webpki-roots")]
         return rustls::ClientConfig::builder()
             .with_webpki_roots()
-            .with_no_client_auth();
-
-        #[cfg(feature = "rustls-platform-verifier")]
-        return rustls::ClientConfig::builder()
-            .with_platform_verifier()
             .with_no_client_auth();
     }
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -284,10 +284,7 @@ mod tests {
             .with_no_client_auth();
     }
 
-    async fn oneshot<S, Req>(mut service: S, req: Req) -> Result<S::Response, S::Error>
-    where
-        S: Service<Req>,
-    {
+    async fn oneshot<S: Service<Uri>>(mut service: S, req: Uri) -> Result<S::Response, S::Error> {
         poll_fn(|cx| service.poll_ready(cx)).await?;
         service.call(req).await
     }


### PR DESCRIPTION
## Proposed release notes

Refactoring in #245 (first released in 0.25.0) broke the optional enforcement of HTTPS only connections (that is, only HTTPS connections can be made through the connector) on the hyper-rustls `HttpsConnector`; this was found and fixed in #295.

Follow-up from #295.