### PR TITLE
Upgrade to webpki-roots 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rustls = { version = "0.23", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.26", default-features = false }
 tower-service = "0.3"
-webpki-roots = { version = "0.26", optional = true }
+webpki-roots = { version = "1", optional = true }
 
 [dev-dependencies]
 cfg-if = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
And prepare a release.

# Release notes

No functional changes -- upgrade to webpki-roots 1 to avoid duplicate dependencies.