### PR TITLE
Upgrade to rustls-platform-verifier 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"
@@ -29,7 +29,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-le
 log = { version = "0.4.4", optional = true }
 pki-types = { package = "rustls-pki-types", version = "1" }
 rustls-native-certs = { version = "0.8", optional = true }
-rustls-platform-verifier = { version = "0.5", optional = true }
+rustls-platform-verifier = { version = "0.6", optional = true }
 rustls = { version = "0.23", default-features = false }
 tokio = "1.0"
 tokio-rustls = { version = "0.26", default-features = false }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "rustls-native-certs")]
 use std::io;
-#[cfg(feature = "rustls-platform-verifier")]
-use std::sync::Arc;
 
 #[cfg(any(
     feature = "rustls-platform-verifier",
@@ -12,6 +10,8 @@ use rustls::client::WantsClientCert;
 use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 #[cfg(feature = "rustls-native-certs")]
 use rustls_native_certs::CertificateResult;
+#[cfg(feature = "rustls-platform-verifier")]
+use rustls_platform_verifier::BuilderVerifierExt;
 
 /// Methods for configuring roots
 ///
@@ -22,9 +22,25 @@ pub trait ConfigBuilderExt: sealed::Sealed {
     ///
     /// See the documentation for [rustls-platform-verifier] for more details.
     ///
+    /// # Panics
+    ///
+    /// Since 0.27.7, this method will panic if the platform verifier cannot be initialized.
+    /// Use `try_with_platform_verifier()` instead to handle errors gracefully.
+    ///
     /// [rustls-platform-verifier]: https://docs.rs/rustls-platform-verifier
+    #[deprecated(since = "0.27.7", note = "use `try_with_platform_verifier` instead")]
     #[cfg(feature = "rustls-platform-verifier")]
     fn with_platform_verifier(self) -> ConfigBuilder<ClientConfig, WantsClientCert>;
+
+    /// Use the platform's native verifier to verify server certificates.
+    ///
+    /// See the documentation for [rustls-platform-verifier] for more details.
+    ///
+    /// [rustls-platform-verifier]: https://docs.rs/rustls-platform-verifier
+    #[cfg(feature = "rustls-platform-verifier")]
+    fn try_with_platform_verifier(
+        self,
+    ) -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, rustls::Error>;
 
     /// This configures the platform's trusted certs, as implemented by
     /// rustls-native-certs
@@ -43,11 +59,15 @@ pub trait ConfigBuilderExt: sealed::Sealed {
 impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
     #[cfg(feature = "rustls-platform-verifier")]
     fn with_platform_verifier(self) -> ConfigBuilder<ClientConfig, WantsClientCert> {
-        let provider = self.crypto_provider().clone();
-        self.dangerous()
-            .with_custom_certificate_verifier(Arc::new(
-                rustls_platform_verifier::Verifier::new().with_provider(provider),
-            ))
+        self.try_with_platform_verifier()
+            .expect("failure to initialize platform verifier")
+    }
+
+    #[cfg(feature = "rustls-platform-verifier")]
+    fn try_with_platform_verifier(
+        self,
+    ) -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, rustls::Error> {
+        BuilderVerifierExt::with_platform_verifier(self)
     }
 
     #[cfg(feature = "rustls-native-certs")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use rustls_native_certs::CertificateResult;
 ///
 /// This adds methods (gated by crate features) for easily configuring
 /// TLS server roots a rustls ClientConfig will trust.
-pub trait ConfigBuilderExt {
+pub trait ConfigBuilderExt: sealed::Sealed {
     /// Use the platform's native verifier to verify server certificates.
     ///
     /// See the documentation for [rustls-platform-verifier] for more details.
@@ -105,4 +105,12 @@ impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
         );
         self.with_root_certificates(roots)
     }
+}
+
+mod sealed {
+    use super::*;
+
+    pub trait Sealed {}
+
+    impl Sealed for ConfigBuilder<ClientConfig, WantsVerifier> {}
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -258,7 +258,7 @@ mod tests {
         let config_builder = rustls::ClientConfig::builder();
         cfg_if::cfg_if! {
             if #[cfg(feature = "rustls-platform-verifier")] {
-                let config_builder = config_builder.with_platform_verifier();
+                let config_builder = config_builder.try_with_platform_verifier()?;
             } else if #[cfg(feature = "rustls-native-certs")] {
                 let config_builder = config_builder.with_native_roots().unwrap();
             } else if #[cfg(feature = "webpki-roots")] {


### PR DESCRIPTION
## Proposed release notes

- Seal the `ConfigBuilderExt` trait. This is an extension trait used to offer a more convenient server verifier configuration API. This is technically a breaking change, but we think it is unlikely that anyone has actually implemented this trait.
- Upgrade to rustls-platform-verifier 0.6. Because the platform verifier is now initializing its root certificate store on some platforms eagerly (on initialization rather than on first use), infallible API for setting up the platform verifier has been deprecated in favor of newly added fallible API.